### PR TITLE
[TS] LPS-120004 Non localizable DDM fields are editable in all the languages

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -360,6 +360,16 @@ AUI.add(
 				if (instance.get('readOnly')) {
 					retVal = true;
 				}
+				else {
+					var form = instance.getForm();
+
+					if (
+						!instance.get('localizable') &&
+						form.getDefaultLocale() != instance.get('displayLocale')
+					) {
+						retVal = true;
+					}
+				}
 
 				return retVal;
 			},
@@ -4151,15 +4161,11 @@ AUI.add(
 				},
 
 				fillEmptyLocales(instance, fields, availableLanguageIds) {
-					var defaultLocale = instance.getDefaultLocale();
-
-					if (availableLanguageIds.indexOf(defaultLocale) === -1) {
-						availableLanguageIds.push(defaultLocale);
-					}
-
 					fields.forEach((field) => {
 						if (field.get('localizable')) {
 							var localizationMap = field.get('localizationMap');
+
+							var defaultLocale = field.getDefaultLocale();
 
 							availableLanguageIds.forEach((locale) => {
 								if (!localizationMap[locale]) {


### PR DESCRIPTION
LPS-120004 Non localizable DDM fields are editable in all the languages, caused by  68b55c49e507ce8ea509c25d945113bb709092f4 , behaviour clarified in https://issues.liferay.com/browse/PTR-1943