### PR TITLE
LPS-122104 - Non localizable DDM boolean fields editable in all lang

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1049,7 +1049,9 @@ AUI.add(
 						}
 
 						var checkboxInput = container.one(
-							'input[type="checkbox"]'
+							'input[type="checkbox"][name*="' +
+								instance.getFieldDefinition().name +
+								'"]'
 						);
 
 						if (checkboxInput) {


### PR DESCRIPTION
Non-localizable DDM boolean fields editable in all the languages when child of a separator field

https://issues.liferay.com/browse/LPS-122104 