### PR TITLE
LPS-123848 Documents not visible when editing dynamic data lists, after upgrade from 6.2 to DXP

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
@@ -29,7 +29,7 @@ Import-Package:\
 	org.tukaani.*;resolution:=optional,\
 	\
 	*
-Liferay-Require-SchemaVersion: 3.9.1
+Liferay-Require-SchemaVersion: 3.10.11
 Liferay-Service: true
 Provide-Capability:\
 	liferay.resource.bundle;\

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/DDMServiceUpgrade.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/DDMServiceUpgrade.java
@@ -47,6 +47,7 @@ import com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util.DDMStructur
 import com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util.DDMStructureVersionTable;
 import com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util.DDMTemplateTable;
 import com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util.DDMTemplateVersionTable;
+import com.liferay.dynamic.data.mapping.internal.upgrade.v3_10_11.UpgradeDDMFormDocumentLibraryFields;
 import com.liferay.dynamic.data.mapping.internal.upgrade.v3_1_0.UpgradeDDMStructureLayout;
 import com.liferay.dynamic.data.mapping.internal.upgrade.v3_2_4.UpgradeDDMContent;
 import com.liferay.dynamic.data.mapping.internal.upgrade.v3_5_0.UpgradeDDMFormInstanceReport;
@@ -375,6 +376,15 @@ public class DDMServiceUpgrade implements UpgradeStepRegistrator {
 			new com.liferay.dynamic.data.mapping.internal.upgrade.v3_9_1.
 				UpgradeDDMStructure(
 					ddmFormJSONDeserializer, ddmFormSerializer));
+
+		registry.register("3.9.1", "3.10.0", new DummyUpgradeStep());
+
+		registry.register(
+			"3.10.0", "3.10.11",
+			new UpgradeDDMFormDocumentLibraryFields(
+				ddmFormJSONDeserializer, ddmFormValuesDeserializer,
+				ddmFormValuesSerializer, _dlFileEntryLocalService,
+				_jsonFactory));
 	}
 
 	@Activate

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_10_11/UpgradeDDMFormDocumentLibraryFields.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_10_11/UpgradeDDMFormDocumentLibraryFields.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.internal.upgrade.v3_10_11;
+
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
+import com.liferay.dynamic.data.mapping.io.DDMFormValuesDeserializer;
+import com.liferay.dynamic.data.mapping.io.DDMFormValuesSerializer;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.Value;
+import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.util.DDMFormDeserializeUtil;
+import com.liferay.dynamic.data.mapping.util.DDMFormFieldValueTransformer;
+import com.liferay.dynamic.data.mapping.util.DDMFormValuesDeserializeUtil;
+import com.liferay.dynamic.data.mapping.util.DDMFormValuesSerializeUtil;
+import com.liferay.dynamic.data.mapping.util.DDMFormValuesTransformer;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @author István András Dézsi
+ */
+public class UpgradeDDMFormDocumentLibraryFields extends UpgradeProcess {
+
+	public UpgradeDDMFormDocumentLibraryFields(
+		DDMFormDeserializer ddmFormDeserializer,
+		DDMFormValuesDeserializer ddmFormValuesDeserializer,
+		DDMFormValuesSerializer ddmFormValuesSerializer,
+		DLFileEntryLocalService dlFileEntryLocalService,
+		JSONFactory jsonFactory) {
+
+		_ddmFormDeserializer = ddmFormDeserializer;
+		_ddmFormValuesDeserializer = ddmFormValuesDeserializer;
+		_ddmFormValuesSerializer = ddmFormValuesSerializer;
+		_dlFileEntryLocalService = dlFileEntryLocalService;
+		_jsonFactory = jsonFactory;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		StringBundler sb = new StringBundler(7);
+
+		sb.append("select DDMContent.contentId, DDMContent.data_, ");
+		sb.append("DDMStructureVersion.structureVersionId, ");
+		sb.append("DDMStructureVersion.definition from DDMContent inner join ");
+		sb.append("DDMStorageLink on DDMContent.contentId = ");
+		sb.append("DDMStorageLink.classPK inner join DDMStructureVersion on ");
+		sb.append("DDMStorageLink.structureVersionId = ");
+		sb.append("DDMStructureVersion.structureVersionId");
+
+		try (PreparedStatement ps1 = connection.prepareStatement(sb.toString());
+			PreparedStatement ps2 =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update DDMContent set data_ = ? where contentId = ?")) {
+
+			try (ResultSet rs = ps1.executeQuery()) {
+				while (rs.next()) {
+					DDMForm ddmForm = DDMFormDeserializeUtil.deserialize(
+						_ddmFormDeserializer, rs.getString("definition"));
+
+					List<DDMFormField> ddmFormFields =
+						ddmForm.getDDMFormFields();
+
+					Stream<DDMFormField> stream = ddmFormFields.stream();
+
+					List<DDMFormField> documentLibraryDDMFormFields =
+						stream.filter(
+							ddmFormField -> ddmFormField.getType(
+							).equals(
+								"ddm-documentlibrary"
+							)
+						).collect(
+							Collectors.toList()
+						);
+
+					if (documentLibraryDDMFormFields.isEmpty()) {
+						continue;
+					}
+
+					String data = rs.getString("data_");
+
+					DDMFormValues ddmFormValues =
+						DDMFormValuesDeserializeUtil.deserialize(
+							data, ddmForm, _ddmFormValuesDeserializer);
+
+					transformDocumentLibraryDDMFormFieldValues(ddmFormValues);
+
+					ps2.setString(
+						1,
+						DDMFormValuesSerializeUtil.serialize(
+							ddmFormValues, _ddmFormValuesSerializer));
+
+					ps2.setLong(2, rs.getLong("contentId"));
+
+					ps2.addBatch();
+				}
+
+				ps2.executeBatch();
+			}
+		}
+	}
+
+	protected void transformDocumentLibraryDDMFormFieldValues(
+			DDMFormValues ddmFormValues)
+		throws Exception {
+
+		DDMFormValuesTransformer ddmFormValuesTransformer =
+			new DDMFormValuesTransformer(ddmFormValues);
+
+		ddmFormValuesTransformer.addTransformer(
+			new DocumentLibraryDDMFormFieldValueTransformer());
+
+		ddmFormValuesTransformer.transform();
+	}
+
+	private final DDMFormDeserializer _ddmFormDeserializer;
+	private final DDMFormValuesDeserializer _ddmFormValuesDeserializer;
+	private final DDMFormValuesSerializer _ddmFormValuesSerializer;
+	private final DLFileEntryLocalService _dlFileEntryLocalService;
+	private final JSONFactory _jsonFactory;
+
+	private class DocumentLibraryDDMFormFieldValueTransformer
+		implements DDMFormFieldValueTransformer {
+
+		@Override
+		public String getFieldType() {
+			return "ddm-documentlibrary";
+		}
+
+		@Override
+		public void transform(DDMFormFieldValue ddmFormFieldValue)
+			throws PortalException {
+
+			Value value = ddmFormFieldValue.getValue();
+
+			for (Locale locale : value.getAvailableLocales()) {
+				String valueString = value.getString(locale);
+
+				if (Validator.isNull(valueString)) {
+					continue;
+				}
+
+				JSONObject jsonObject = _jsonFactory.createJSONObject(
+					valueString);
+
+				long groupId = jsonObject.getLong("groupId");
+				String uuid = jsonObject.getString("uuid");
+
+				DLFileEntry dlFileEntry =
+					_dlFileEntryLocalService.getFileEntryByUuidAndGroupId(
+						uuid, groupId);
+
+				jsonObject.put("title", dlFileEntry.getTitle());
+
+				value.addString(locale, jsonObject.toString());
+			}
+		}
+
+	}
+
+}


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

This new upgrade process adds the "title" to the field with the "ddm-documentlibrary" type so the file name will be visible in the edit mask.

Thank you and best regards,
István