### PR TITLE
LPS-124669 Always the default value of the select field is shown when adding a new web content translation

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -819,7 +819,13 @@ AUI.add(
 							predefinedValue = field.predefinedValue[locale];
 						}
 
-						if (type === 'select' && predefinedValue === '[""]') {
+						var localizationMap = instance.get('localizationMap');
+
+						if (
+							type === 'select' &&
+							(predefinedValue === '[""]' ||
+								!A.Object.isEmpty(localizationMap))
+						) {
 							predefinedValue = '';
 						}
 					}


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

As the ER Team cannot process the pr https://github.com/liferay/liferay-portal-ee/pull/22080, I'm sending this pull to master albeit the issue cannot be reproduced due to UI changes. In theory, it could be reproduced on master as well if structures wouldn't be built with the data engine.

-----------------------------------------------------

A customer reported that when using a web content structure with a Select field with a predefined (aka default) value, and adding translations to a web content where for the default language they already chose another value in that field, the new translations are always opened with the default option in the field, not with the option chosen for the default version (language) of that web content.
This didn't use to be like that with 6.2. There it was working as they expected: the option chosen for the default language was taken into consideration.

-----------------------------------------------------

I added a new condition for checking if a value has been selected in the Select field so the behavior they except will be achieved.
Once a value is chosen, switching to a translation will ignore the default value set for that specific language.

Please let me know if this is would be the correct behavior or the current is the intended one. 

Thank you and best regards,
István