### PR TITLE
LPS-125448 Check form field options if dataSourceType is empty

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValidatorImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValidatorImpl.java
@@ -199,7 +199,9 @@ public class DDMFormValidatorImpl implements DDMFormValidator {
 			return;
 		}
 
-		if (!Objects.equals(ddmFormField.getDataSourceType(), "manual")) {
+		if (!Validator.isBlank(ddmFormField.getDataSourceType()) &&
+			!Objects.equals(ddmFormField.getDataSourceType(), "manual")) {
+
 			return;
 		}
 


### PR DESCRIPTION
Hi! I've checked [this issue](https://issues.liferay.com/browse/LPS-125448) and seen that form fields are not being validated if it's dataSourceType is empty. I am not sure if this is expected or select field's dataSourceType should be set to "manual" by default.

Can you confirm if this is a valid solution?