### PR TITLE
LPS-125369 move the logic of getting the title translated value to back-end

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
@@ -38,7 +38,6 @@ import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
-import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
@@ -68,12 +67,14 @@ import com.liferay.portal.util.PropsValues;
 
 import java.io.File;
 
+import java.util.Arrays;
 import java.util.Calendar;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -141,17 +142,22 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 			uploadPortletRequest, "articleId");
 		double version = ParamUtil.getDouble(uploadPortletRequest, "version");
 
-		Map<Locale, String> titleMap = new HashMap<>();
+		Map<Locale, String> titleMap = LocalizationUtil.getLocalizationMap(
+			actionRequest, "titleMapAsXML");
 
-		JSONObject titleValueJSONObject = _jsonFactory.createJSONObject(
-			ParamUtil.getString(uploadPortletRequest, "titleValue"));
+		List<String> titleTranslatedLanguageIds = Arrays.asList(
+			StringUtil.split(
+				ParamUtil.getString(
+					uploadPortletRequest, "titleTranslatedLanguageIds")));
 
-		Set<String> languageIds = titleValueJSONObject.keySet();
+		Stream<String> stream = titleTranslatedLanguageIds.stream();
 
-		languageIds.forEach(
-			languageId -> titleMap.put(
-				LocaleUtil.fromLanguageId(languageId),
-				titleValueJSONObject.getString(languageId)));
+		Map<Locale, String> translatedTitleMap = stream.map(
+			titleTranslatedLanguageId -> LocaleUtil.fromLanguageId(
+				titleTranslatedLanguageId)
+		).collect(
+			Collectors.toMap(locale -> locale, locale -> titleMap.get(locale))
+		);
 
 		String ddmStructureKey = ParamUtil.getString(
 			uploadPortletRequest, "ddmStructureKey");
@@ -317,9 +323,9 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 
 			article = _journalArticleService.addArticle(
 				groupId, folderId, classNameId, classPK, articleId,
-				autoArticleId, titleMap, descriptionMap, friendlyURLMap,
-				content, ddmStructureKey, ddmTemplateKey, layoutUuid,
-				displayDateMonth, displayDateDay, displayDateYear,
+				autoArticleId, translatedTitleMap, descriptionMap,
+				friendlyURLMap, content, ddmStructureKey, ddmTemplateKey,
+				layoutUuid, displayDateMonth, displayDateDay, displayDateYear,
 				displayDateHour, displayDateMinute, expirationDateMonth,
 				expirationDateDay, expirationDateYear, expirationDateHour,
 				expirationDateMinute, neverExpire, reviewDateMonth,
@@ -338,7 +344,7 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 
 			if (actionName.equals("/journal/update_article")) {
 				article = _journalArticleService.updateArticle(
-					groupId, folderId, articleId, version, titleMap,
+					groupId, folderId, articleId, version, translatedTitleMap,
 					descriptionMap, friendlyURLMap, content, ddmStructureKey,
 					ddmTemplateKey, layoutUuid, displayDateMonth,
 					displayDateDay, displayDateYear, displayDateHour,

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -64,7 +64,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
 					<aui:input autoFocus="<%= (article == null) || article.isNew() %>" cssClass="form-control-inline" defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>" label="" localized="<%= true %>" name="titleMapAsXML" placeholder='<%= LanguageUtil.format(request, "untitled-x", HtmlUtil.escape(ddmStructure.getName(locale))) %>' required="<%= journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT %>" selectedLanguageId="<%= journalEditArticleDisplayContext.getSelectedLanguageId() %>" type="text" wrapperCssClass="article-content-title mb-0" />
-					<aui:input name="titleValue" type="hidden" />
+					<aui:input name="titleTranslatedLanguageIds" type="hidden" />
 				</li>
 				<li class="tbar-item">
 					<div class="journal-article-button-row tbar-section text-right">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -153,23 +153,17 @@ class JournalPortlet extends PortletBase {
 		return document.getElementById(this.ns(name));
 	}
 
-	_getInputLocalizedValues(field) {
+	_getInputTranslatedLanguages(field) {
 		const inputLocalized = Liferay.component(this.ns(field));
-		const localizedValues = {};
+		let translatedLanguages = [];
 
 		if (inputLocalized) {
-			const translatedLanguages = inputLocalized
+			translatedLanguages = inputLocalized
 				.get('translatedLanguages')
 				.values();
-
-			translatedLanguages.forEach((languageId) => {
-				localizedValues[languageId] = inputLocalized.getValue(
-					languageId
-				);
-			});
 		}
 
-		return JSON.stringify(localizedValues);
+		return translatedLanguages.toString();
 	}
 
 	/**
@@ -266,9 +260,13 @@ class JournalPortlet extends PortletBase {
 			articleIdInput.value = newArticleIdInput.value;
 		}
 
-		const titleValueInput = this._getInputByName(this.ns('titleValue'));
+		const titleTranslatedLanguageIdsInput = this._getInputByName(
+			this.ns('titleTranslatedLanguageIds')
+		);
 
-		titleValueInput.value = this._getInputLocalizedValues('titleMapAsXML');
+		titleTranslatedLanguageIdsInput.value = this._getInputTranslatedLanguages(
+			'titleMapAsXML'
+		);
 
 		const form = this._getInputByName(this.ns('fm1'));
 


### PR DESCRIPTION
This is a follow up for https://issues.liferay.com/browse/LPS-125369
I'm moving the logic of getting the translated values for the article title to backend due to https://issues.liferay.com/browse/LRQA-64147. This issue only occurs when Poshi test is running and we are not able to reproduce it manually. Somehow, the localzed-input value is not updated at the moment that _saveArticle is running. So the solution I found was just send the translated languages to backend and filter the values there