### PR TITLE
[DE-Migration] LPS-125539 Parsing geolocation values to object

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -38,6 +38,7 @@ const convertInputValue = (fieldType, value) => {
 	}
 	else if (
 		fieldType === 'document_library' ||
+		fieldType === 'geolocation' ||
 		fieldType === 'grid' ||
 		fieldType === 'image'
 	) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
@@ -126,8 +126,13 @@ export const useGeolocation = ({
 			const mapConfig = {...MAP_CONFIG};
 			mapConfig.boundingBox = `#map_${instanceId}`;
 
-			if (value && disabled) {
-				mapConfig.position.location = JSON.parse(value);
+			if (value) {
+				if (typeof value === 'string') {
+					mapConfig.position.location = JSON.parse(value);
+				}
+				else {
+					mapConfig.position.location = value;
+				}
 			}
 
 			switch (mapProviderKey) {


### PR DESCRIPTION
- LPS-125088 Revert changes from LPS-124715 since they are incomplete.  When looking at an article from the user perspective in a web content display, comments should be present from all versions, so use the resourcePrimKey value, regardless of version number.
- LPS-125088 When commenting on a workflow task, we need to differentiate these comments between versions AND from the article comments displayed from the web content display.  The best way to do this is to use the classPK value (id_ column for JournalArticle object).
- LPS-125088 Lets not force the classPK/className to correspond to an assetEntry, otherwise there is no way to store comments related to JournalArticle and it's workflow tasks independantly.  LPS-91380 is still resolved after these changes.
- LPS-125639 Format language id to shat it uses a hyphen instead of the underscore
- LPS-125639 Do not autoclose error
- LRQA-64243 Remove unnecessary step
- LPS-123588 Showing creation menu inside the item selector
- LPS-123588 Keeping the current windowState to avoid showing navigation inside the item selector modal
- LPS-123588 Using the module's resource bundle to fix missing language key from external modules (item selector)
- LPS-123588 Adding error log
- LPS-123588 Moving to a better package
- LPS-123588 Moving to an even better package
- subrepo:ignore Update 'modules/etl/mulesoft/.gitrepo'.
- LPS-124922 Add path for the twitch play button
- LPS-124922 Add path for the inactive twitch video
- LPS-124922 Update macros for preview the video shortcut
- LPS-124922 Add macro for viewing the played twitch video
- LPS-124922 Add tests for the video shortcut
- LPS-124922 Update test for viewing twitch video in the item selector
- LPS-124922 Add parameter for the tests and macro
- LPS-123895 Add path for view video thumbnail
- LPS-123895 Add macros for view thumbnails in item selector
- LPS-123895 Add tests for view video thumbnails
- LPS-125338 Add test for the google drive
- LPS-107165 Update locator of DM status
- LPS-107165 Add test about editing google doc with workflow
- LPS-122723 Update macro to add child site by parent site
- LPS-122723 Update test to connect child site by parent site
- LPS-113488 Add test about viewing document that the author is deleted
- LPS-125409 Use languageId from request when available for asset entry title
- LPS-125564 Rebuild layout page template structure before export when is doesn't exist yet
- LPS-125564 Remove existing rels before importing them
- LPS-125564 Don't break up flow
- LPS-125422 Make function to create repeated fields recursive so nested fields localized value is also cleared
- LPS-125290 Remove bottom border from activity section content
- LPS-121804 Add PythonImportsCheck
- LPS-121804 Add logic
- LPS-121804 Preserve indentation
- LPS-121804 Add empty line
- LPS-121804 Add testcases
- LPS-121804 Generated
- LPS-121804 SF
- LPS-121804 prep next
- LPS-121804 prep next
- LPS-125629 add support for deprecated schemas, operations and parameters
- LPS-125629 generate
- LPS-125629 SF
- LPS-125629 prep next
- LPS-125629 prep next
- LPS-114942 Replace CollapsablePanel to ClayPanel
- LPS-125463 separator field needs to have an input so we can create repeatable fields properly
- LPS-125463 do not override localizedValue when it is undefined
- LPS-125463 reuse
- LPS-125463 check if localizeddValue exists
- LPS-125463 add value to dataRecordValues even if localized value does not exist
- LPS-125463 remove separator type check so we can repeat it properly
- LPS-125448 Check form field options if dataSourceType is empty
- LPS-125660 Improve REST Builder generation to consider external references from inner properties inside components
- LPS-125660 SF
- LPS-125660 prep next
- LPS-125644 Adds missing dsannotations-options. We need it since we are extending and abstract class that has service reference. And since the annotation is not present, NPEs are thrown
- LPS-125379 dataLayoutField is set to required false after be deleted
- LPS-125450 Deprecated old constructor
- LPS-123631 Stop using LicenseManager#checkUserLicense as it is going to be removed
- LPS-125482 Use getTitle method to grab the correctly cased title
- LPS-125539 Parsing geolocation values to object
