### PR TITLE
[DE-Migration] LPS-127666 Now that the component does not change its name/id due to the instanceId being reused, useState is not sufficient to set the initialValue after re-render

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/CheckboxMultiple/CheckboxMultiple.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/CheckboxMultiple/CheckboxMultiple.es.js
@@ -14,7 +14,7 @@
 
 import {ClayCheckbox} from '@clayui/form';
 import classNames from 'classnames';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
 import {setJSONArrayValue} from '../util/setters.es';
@@ -68,6 +68,10 @@ const CheckboxMultiple = ({
 	value: initialValue,
 }) => {
 	const [value, setValue] = useState(initialValue);
+
+	useEffect(() => {
+		setValue(initialValue);
+	}, [initialValue]);
 
 	const displayValues = value && value.length > 0 ? value : predefinedValue;
 	const Toggle = isSwitcher ? Switcher : ClayCheckbox;


### PR DESCRIPTION
Related ticket: https://issues.liferay.com/browse/LPS-127666