### PR TITLE
[DE-Migration] LPS-125435 Add DDMFormFieldValidation to XStream allowed types

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/io/util/DDMFormFieldDeserializerUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/io/util/DDMFormFieldDeserializerUtil.java
@@ -139,23 +139,22 @@ public class DDMFormFieldDeserializerUtil {
 		JSONObject expressionJSONObject = jsonObject.getJSONObject(
 			"expression");
 
+		DDMFormFieldValidationExpression ddmFormFieldValidationExpression =
+			new DDMFormFieldValidationExpression();
+
 		if (expressionJSONObject != null) {
-			ddmFormFieldValidation.setDDMFormFieldValidationExpression(
-				new DDMFormFieldValidationExpression() {
-					{
-						setName(expressionJSONObject.getString("name"));
-						setValue(expressionJSONObject.getString("value"));
-					}
-				});
+			ddmFormFieldValidationExpression.setName(
+				expressionJSONObject.getString("name"));
+			ddmFormFieldValidationExpression.setValue(
+				expressionJSONObject.getString("value"));
 		}
 		else {
-			ddmFormFieldValidation.setDDMFormFieldValidationExpression(
-				new DDMFormFieldValidationExpression() {
-					{
-						setValue(jsonObject.getString("expression"));
-					}
-				});
+			ddmFormFieldValidationExpression.setValue(
+				jsonObject.getString("expression"));
 		}
+
+		ddmFormFieldValidation.setDDMFormFieldValidationExpression(
+			ddmFormFieldValidationExpression);
 
 		ddmFormFieldValidation.setParameterLocalizedValue(
 			_deserializeLocalizedValue(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/xstream/configurator/DynamicDataMappingXStreamConfigurator.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/xstream/configurator/DynamicDataMappingXStreamConfigurator.java
@@ -18,6 +18,7 @@ import com.liferay.dynamic.data.mapping.kernel.DDMFormField;
 import com.liferay.dynamic.data.mapping.kernel.DDMFormFieldOptions;
 import com.liferay.dynamic.data.mapping.kernel.DDMFormValues;
 import com.liferay.dynamic.data.mapping.kernel.LocalizedValue;
+import com.liferay.dynamic.data.mapping.model.DDMFormFieldValidation;
 import com.liferay.dynamic.data.mapping.model.impl.DDMStructureImpl;
 import com.liferay.dynamic.data.mapping.model.impl.DDMTemplateImpl;
 import com.liferay.exportimport.kernel.xstream.XStreamAlias;
@@ -72,6 +73,7 @@ public class DynamicDataMappingXStreamConfigurator
 				com.liferay.dynamic.data.mapping.storage.DDMFormValues.class),
 			new XStreamType(DDMFormField.class),
 			new XStreamType(DDMFormFieldOptions.class),
+			new XStreamType(DDMFormFieldValidation.class),
 			new XStreamType(DDMFormValues.class),
 			new XStreamType(LocalizedValue.class)
 		};


### PR DESCRIPTION
Relevant ticket: https://issues.liferay.com/browse/LPS-125435