### PR TITLE
LPS-127671 Avoid wrapping topper text

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/_variables.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/_variables.scss
@@ -18,8 +18,6 @@ $toolbarHeight: 64px;
 // ---------- Regular sizes ----------
 
 $animation: cubic-bezier(0.25, 0.1, 0.25, 1);
-$sidebarMainWidth: 326px;
-$sidebarMiniWidth: 72px;
 
 // z-indexes, ordered numerically.
 

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/components/_ddm_form_builder.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/components/_ddm_form_builder.scss
@@ -9,6 +9,7 @@
 	}
 
 	&.ddm-form-builder {
+		padding-right: $sidebarMiniWidth;
 		transition: padding ease 0.5s;
 
 		&--sidebar-open {
@@ -126,6 +127,7 @@
 }
 
 .data-engine-form-builder-messages {
+	padding-right: $sidebarMiniWidth;
 	transition: padding ease 0.5s;
 
 	&--collapsed {

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/components/_ddm_form_builder.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/components/_ddm_form_builder.scss
@@ -9,12 +9,13 @@
 	}
 
 	&.ddm-form-builder {
-		padding-right: $sidebarMiniWidth;
+		padding-right: $multiPanelSidebarButtonWidth;
 		transition: padding ease 0.5s;
 
 		&--sidebar-open {
 			padding-left: 0;
-			padding-right: $sidebarMainWidth + $sidebarMiniWidth;
+			padding-right: $multiPanelSidebarContentWidth +
+				$multiPanelSidebarButtonWidth;
 		}
 
 		.col-ddm {
@@ -127,11 +128,12 @@
 }
 
 .data-engine-form-builder-messages {
-	padding-right: $sidebarMiniWidth;
+	padding-right: $multiPanelSidebarButtonWidth;
 	transition: padding ease 0.5s;
 
 	&--collapsed {
-		padding-right: $sidebarMainWidth + $sidebarMiniWidth;
+		padding-right: $multiPanelSidebarContentWidth +
+			$multiPanelSidebarButtonWidth;
 	}
 
 	.alert {

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/components/_sidebar.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/components/_sidebar.scss
@@ -1,28 +1,4 @@
 .data-layout-builder-sidebar {
-	&.main {
-		transform: translateX(0%);
-		transition: transform 0.3s $animation, opacity 0.3s $animation;
-		width: $sidebarMainWidth;
-		z-index: 50;
-
-		&.closed {
-			opacity: 0;
-			transform: translateX($sidebarMainWidth - $sidebarMiniWidth);
-		}
-	}
-
-	&.mini {
-		padding: 16px;
-		transform: translateX(0%);
-		transition: transform 0.3s $animation;
-		width: $sidebarMiniWidth;
-		z-index: 60;
-
-		&.closed {
-			transform: translateX($sidebarMiniWidth);
-		}
-	}
-
 	.sidebar {
 		box-shadow: none;
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_actionable.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_actionable.scss
@@ -4,6 +4,7 @@
 	border-top-left-radius: 4px;
 	border-top-right-radius: 4px;
 	color: #fff;
+	display: flex;
 	font-weight: 600;
 	height: 28px;
 	justify-content: space-between;
@@ -11,6 +12,7 @@
 	padding: 0 0 2px 8px;
 	position: absolute;
 	top: -30px;
+	white-space: nowrap;
 	width: auto;
 	z-index: 50;
 


### PR DESCRIPTION
Hey there!

In the first three commits I just tried to remove some CSS that was not being used, but feel free to remove them if there is something wrong.

For the bug fix. I just forced the text to not wrapping, but the result is this (not the best):
![image](https://user-images.githubusercontent.com/800645/108200110-3eb5ee00-711e-11eb-9414-66abfb64a6ea.png)