### PR TITLE
[DE-Migration] LPS-128202 With the current implementation it is possible to have values for a field that does not exist. Therefore, we have to bypass that during the upgrade.

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_0_0/UpgradeDDMField.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_0_0/UpgradeDDMField.java
@@ -457,8 +457,10 @@ public class UpgradeDDMField extends UpgradeProcess {
 				DDMFormField ddmFormField = ddmFormFieldsMap.get(
 					ddmFieldInfo._fieldName);
 
-				fieldType = ddmFormField.getType();
-				localizable = ddmFormField.isLocalizable();
+				if (ddmFormField != null) {
+					fieldType = ddmFormField.getType();
+					localizable = ddmFormField.isLocalizable();
+				}
 			}
 
 			insertDDMFieldPreparedStatement.setLong(1, fieldId);


### PR DESCRIPTION
Relevant ticket: https://issues.liferay.com/browse/LPS-128202