### PR TITLE
LPS-127963 format current date value if not initialValueMemoized

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
@@ -156,11 +156,9 @@ const DatePicker = ({
 				showMask: true,
 			});
 
-			if (initialValueMemoized) {
-				inputRef.current.value = moment(initialValueMemoized).format(
-					dateMask.toUpperCase()
-				);
-			}
+			inputRef.current.value = moment(
+				initialValueMemoized || inputRef.current.value
+			).format(dateMask.toUpperCase());
 
 			maskInstance.current.update(inputRef.current.value);
 		}


### PR DESCRIPTION
LPS-127963

When changing to a locale with a format in which the current date is incorrect (20/02/2020 to MM/dd/yyyy) it put a invalid value and shows a message of error on the datePicker (and you can't change it again without exiting the WC)

So format the current value seems to solve it, not only the initialValueMemoized