### PR TITLE
LPS-127671 Revert "Set minimum column size two 2 and adjust resizing"

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withResizeableColumns.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withResizeableColumns.es.js
@@ -17,9 +17,7 @@ import Component from 'metal-jsx';
 
 import formBuilderProps from './props.es';
 
-export const MAX_COLUMNS = 12;
-
-export const MIN_COLUMN_SIZE = 2;
+const MAX_COLUMNS = 12;
 
 const withResizeableColumns = (ChildComponent) => {
 	class ResizeableColumns extends Component {
@@ -103,34 +101,34 @@ const withResizeableColumns = (ChildComponent) => {
 				container.classList.add('dragging');
 			}
 
-			const columnSizeRatio = Math.min(
-				Math.max(
-					(event.x - this._currentRow.getBoundingClientRect().left) /
-						this._currentRow.clientWidth,
-					0
-				),
-				1
+			let column = Math.floor(
+				((event.x - this._currentRow.getBoundingClientRect().left) *
+					(MAX_COLUMNS * 10)) /
+					this._currentRow.clientWidth /
+					10
 			);
 
-			const column =
-				Math.round((columnSizeRatio * MAX_COLUMNS) / MIN_COLUMN_SIZE) *
-				MIN_COLUMN_SIZE;
+			if (column > MAX_COLUMNS - 1) {
+				column = MAX_COLUMNS - 1;
+			}
 
-			if (column !== this._lastResizeColumn) {
-				this._lastResizeColumn = column;
-
+			if (column >= 0) {
 				const direction = source.classList.contains(
 					'ddm-resize-handle-left'
 				)
 					? 'left'
 					: 'right';
 
-				store.emit('columnResized', {
-					column,
-					container,
-					direction,
-					source,
-				});
+				if (this._lastResizeColumn !== column) {
+					this._lastResizeColumn = column;
+
+					store.emit('columnResized', {
+						column,
+						container,
+						direction,
+						source,
+					});
+				}
 			}
 		}
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/handlers/columnResizedHandler.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/handlers/columnResizedHandler.es.js
@@ -14,10 +14,6 @@
 
 import {FormSupport} from 'dynamic-data-mapping-form-renderer';
 
-import {
-	MAX_COLUMNS,
-	MIN_COLUMN_SIZE,
-} from '../../FormBuilder/withResizeableColumns.es';
 import {updateField} from '../util/settingsContext.es';
 
 const getColumn = (pages, nestedIndexes = []) => {
@@ -150,19 +146,16 @@ export const handleResizeRight = (
 		) {
 			newCurrentColumn = {
 				...currentColumn,
-				size: Math.max(currentColumn.size - newSize, MIN_COLUMN_SIZE),
+				size: Math.max(currentColumn.size - newSize, 1),
 			};
 
 			newNextColumn = {
 				...nextColumn,
-				size: Math.min(nextColumn.size + newSize, MAX_COLUMNS),
+				size: Math.min(nextColumn.size + newSize, 12),
 			};
 		}
 		else if (columnTarget > currentColumnPosition) {
-			if (
-				nextColumn.size === MIN_COLUMN_SIZE &&
-				nextColumn.fields.length === 0
-			) {
+			if (nextColumn.size === 1 && nextColumn.fields.length === 0) {
 				newCurrentColumn = {
 					...currentColumn,
 					size: currentColumn.size + newSize,
@@ -277,7 +270,7 @@ const handleResizeLeft = (props, state, source, indexes, columnTarget) => {
 	}
 	else if (
 		previousColumn &&
-		previousColumn.size === MIN_COLUMN_SIZE &&
+		previousColumn.size === 1 &&
 		previousColumn.fields.length === 0 &&
 		columnTarget <= previousColumnPosition
 	) {
@@ -297,7 +290,7 @@ const handleResizeLeft = (props, state, source, indexes, columnTarget) => {
 			columnIndex - 1,
 			{
 				...currentColumn,
-				size: currentColumn.size + MIN_COLUMN_SIZE,
+				size: currentColumn.size + 1,
 			}
 		);
 	}
@@ -375,7 +368,7 @@ export default (props, state, source, container, column, direction) => {
 				state,
 				source,
 				sourceIndexes,
-				column
+				column + 1
 			);
 		}
 	}


### PR DESCRIPTION
This reverts commit 247cbe14bcde321b3a8f287585e76502139478cb.

We are reversing this implementation because it implements a behavior different from what would be expected, we must consider that the minimum column size must be only 2 but allow the resize to be done one by one. The way it was implemented, the user is unable to create a column with size 3, only two by two, that is, just even numbers

An important point is that we should test if the Form loads a form with non-even fields, the resize will correct and mess up the layout since it will only have even-sized columns.

cc @p2kmgcl