### PR TITLE
LPS-128617 on the fieldSets the field localizable is null because is not part of the settings, and the localizable field is true by default, so in the case of the null case is applying the default value

### DIFF
--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/dto/v2_0/util/DataDefinitionDDMFormUtil.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/dto/v2_0/util/DataDefinitionDDMFormUtil.java
@@ -203,7 +203,7 @@ public class DataDefinitionDDMFormUtil {
 				dataDefinitionField.getLabel(),
 				LocaleUtil.fromLanguageId(languageId)));
 		ddmFormField.setLocalizable(
-			GetterUtil.getBoolean(dataDefinitionField.getLocalizable()));
+			GetterUtil.getBoolean(dataDefinitionField.getLocalizable(), true));
 		ddmFormField.setName(dataDefinitionField.getName());
 		ddmFormField.setNestedDDMFormFields(
 			_toDDMFormFields(


### PR DESCRIPTION
Hi,

Another solution is to add the _localizable_ on _FieldSetDDMFormFieldTypeSettings_ but the _localizable_ attribute will appear **always** on the screen. But this way we are assuring that the default value is true as on https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/DefaultDDMFormFieldTypeSettings.java#L97

Thanks @marcelabc for the help!!