### PR TITLE
LPS-129346 Prevents moving a FieldGroup into itself and into another FieldGroup

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/handlers/fieldMovedHandler.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/handlers/fieldMovedHandler.es.js
@@ -35,29 +35,6 @@ export default (props, state, event) => {
 		sourceFieldName
 	);
 
-	if (sourceField.type === 'fieldset') {
-		const targetParentField = FormSupport.findFieldByFieldName(
-			[
-				{
-					rows: [
-						{
-							columns: [
-								{
-									fields: [sourceField],
-								},
-							],
-						},
-					],
-				},
-			],
-			targetParentFieldName
-		);
-
-		if (targetParentField) {
-			return;
-		}
-	}
-
 	let mergedState = {
 		...handleFieldDeleted(props, state, {
 			activePage: sourceFieldPage,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/components/PageRenderer/EditorVariant.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/components/PageRenderer/EditorVariant.es.js
@@ -61,7 +61,8 @@ export const Column = ({
 
 	const {canDrop, drop, overTarget} = useDrop({
 		columnIndex,
-		fieldName: column.fields[0]?.fieldName,
+		field: firstField,
+		fieldName: firstField?.fieldName,
 		origin: DND_ORIGIN_TYPE.FIELD,
 		pageIndex,
 		parentField,
@@ -71,8 +72,13 @@ export const Column = ({
 	const [{isDragging}, drag, preview] = useDrag({
 		item: {
 			data: firstField ?? undefined,
-			pageIndex,
 			preview: () => <FieldDragPreview containerRef={resizeRef} />,
+			sourceIndexes: {
+				columnIndex,
+				pageIndex,
+				rowIndex,
+			},
+			sourceParentField: parentField,
 			type: DragTypes.DRAG_FIELD_TYPE_MOVE,
 		},
 	});
@@ -124,7 +130,9 @@ export const Column = ({
 					selected: editable && firstField.fieldName === activeId,
 					'target-droppable': canDrop,
 					'target-over targetOver':
-						(!rootParentField.ddmStructureId && overTarget) ||
+						(!rootParentField.ddmStructureId &&
+							overTarget &&
+							canDrop) ||
 						resizing,
 				})}
 				column={column}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/components/Placeholder.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/components/Placeholder.es.js
@@ -27,7 +27,7 @@ export const Placeholder = ({
 	size,
 }) => {
 	const parentField = useContext(ParentFieldContext);
-	const {drop, overTarget} = useDrop({
+	const {canDrop, drop, overTarget} = useDrop({
 		columnIndex: columnIndex ?? 0,
 		origin: DND_ORIGIN_TYPE.EMPTY,
 		pageIndex,
@@ -46,7 +46,9 @@ export const Placeholder = ({
 			<div
 				className={classnames('ddm-target', {
 					'target-over targetOver':
-						overTarget && !parentField.root?.ddmStructureId,
+						overTarget &&
+						canDrop &&
+						!parentField.root?.ddmStructureId,
 				})}
 				ref={!parentField.root?.ddmStructureId ? drop : undefined}
 			/>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/hooks/useDrop.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/hooks/useDrop.es.js
@@ -134,24 +134,6 @@ export const useDrop = ({
 				return;
 			}
 
-			const {
-				dataDefinition,
-				fieldSet,
-				name,
-				properties,
-				useFieldName,
-			} = data;
-
-			const {fieldType, label, settingsContext} =
-				(dataDefinition &&
-					DataConverter.getDataDefinitionFieldByFieldName({
-						dataDefinition,
-						editingLanguageId,
-						fieldName: name,
-						fieldTypes,
-					})) ??
-				{};
-			const {availableLanguageIds, defaultLanguageId} = fieldSet ?? {};
 			switch (type) {
 				case DragTypes.DRAG_FIELD_TYPE_ADD:
 					dispatch({
@@ -190,7 +172,20 @@ export const useDrop = ({
 						type: EVENT_TYPES.DND.MOVE,
 					});
 					break;
-				case DragTypes.DRAG_DATA_DEFINITION_FIELD_ADD:
+				case DragTypes.DRAG_DATA_DEFINITION_FIELD_ADD: {
+					const {dataDefinition, name} = data;
+
+					const {
+						fieldType,
+						label,
+						settingsContext,
+					} = DataConverter.getDataDefinitionFieldByFieldName({
+						dataDefinition,
+						editingLanguageId,
+						fieldName: name,
+						fieldTypes,
+					});
+
 					dispatch({
 						payload: {
 							data: {
@@ -218,7 +213,12 @@ export const useDrop = ({
 								: EVENT_TYPES.SECTION.ADD,
 					});
 					break;
-				case DragTypes.DRAG_FIELDSET_ADD:
+				}
+				case DragTypes.DRAG_FIELDSET_ADD: {
+					const {fieldSet, properties, useFieldName} = data;
+
+					const {availableLanguageIds, defaultLanguageId} = fieldSet;
+
 					dispatch({
 						payload: {
 							availableLanguageIds,
@@ -240,6 +240,7 @@ export const useDrop = ({
 						type: EVENT_TYPES.FIELD_SET.ADD,
 					});
 					break;
+				}
 				default:
 					break;
 			}


### PR DESCRIPTION
Hey Data Engine Team 👋,

This change brings some improvements and covers some more cases of this problem, this seems to have been partially corrected at https://issues.liferay.com/browse/LPS-128117 but will correct for Forms after Forms stopped using LayoutProvider.

The LayoutProvider implementation did not deal well with preventing a FieldGroup from moving inside into itself, because it did not give Feedback to the user that this is not possible and was an expensive operation when trying to search for the target within the source with the visitor and also it is not the appropriate place to be added, it is the responsibility of the DnD mechanism.

There were also other untreated behaviors, such as:

- Drop the common Field inside itself
- Drop a FieldGroup inside any Field (This means that the FieldGroup can be added in a placeholder.)

These behaviors were not perceived because there was a `try catch` that captured the handlers' errors and suppressed what is invisible to the user if it worked or was wrong and it was also an insecure and sensitive way to deal with these use cases.

---

Move a FieldGroup into itself, In conventional mode, we would be visiting all the fields within it to check if the target belongs to the Field root (in this case the source), but this can be very slow depending on the depth and it is very expensive in this hot path instead this method implement heuristic algorithm based on two assumptions:

- The target indexes are the same as the source indexes
- The target depth is greater than the source

The indexes are an `Array<Object>` that contains the index of the Field according to the depth level, the head of the array is the current loc and the tail is the root of the tree. It does not compare all target indexes just up to the same level of depth as the source.

```js
[
  {pageIndex: 0, rowIndex: 1, columnIndex: 0}, // <- Head (deeper)
  {pageIndex: 0, rowIndex: 0, columnIndex: 0},
  {pageIndex: 0, rowIndex: 0, columnIndex: 0}, // <- Tail (root)
]
```

The comparison of the indexes also fails in the first index that is not equal to the source index to fail early.

---

The last commit is not related to these problems mentioned above, but only an improvement in the declaration of variables that were degrading the readability.