### PR TITLE
LPS-129245 | Cannot add a new Form View in App Builder Objects or a DEDataDefinitionFieldLink due to inconsistent types for fieldName

### DIFF
--- a/modules/apps/data-engine/data-engine-service/src/main/java/com/liferay/data/engine/internal/upgrade/DEServiceUpgrade.java
+++ b/modules/apps/data-engine/data-engine-service/src/main/java/com/liferay/data/engine/internal/upgrade/DEServiceUpgrade.java
@@ -16,6 +16,7 @@ package com.liferay.data.engine.internal.upgrade;
 
 import com.liferay.data.engine.internal.upgrade.v1_0_0.SchemaUpgradeProcess;
 import com.liferay.data.engine.internal.upgrade.v2_0_0.UpgradeCompanyId;
+import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeCTModel;
 import com.liferay.portal.kernel.upgrade.UpgradeMVCCVersion;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -35,7 +36,9 @@ public class DEServiceUpgrade implements UpgradeStepRegistrator {
 	public void register(Registry registry) {
 		registry.register("1.0.0", "1.1.0", new SchemaUpgradeProcess());
 
-		registry.register("1.1.0", "2.0.0", new UpgradeCompanyId());
+		registry.register("1.1.0", "1.1.1", new DummyUpgradeStep());
+
+		registry.register("1.1.1", "2.0.0", new UpgradeCompanyId());
 
 		registry.register(
 			"2.0.0", "2.1.0",


### PR DESCRIPTION
Hi @liferay-data-engine,

This pr is part of the solution to LPS-129245 which affects `7.2.X` and `7.3.X`. `master` is not directly affected due to LPS-124577 but the complete solution requires an upgrade step in `7.2.X` that needs to mirrored by a `DummyUpgradeStep` in `master`. 

The solution in `7.3.X` will also include a `DummyUpgradeStep` as well as an actual upgrade step virtually identical to that in LPS-124577, which will update the column `fieldName` in table `DEDataDefinitionFieldLink` from `LONG` to `VARCHAR(75)`. (Draft solution for `7.3.X`: https://github.com/liferay/liferay-portal-ee/compare/7.3.x...ricardocousolr:LPS-129245_73x)

The solution in `7.2.X` will only include an upgrade step to change the column `fieldName from `LONG` to `VARCHAR(75)`. (Draft solution for `7.2.X`: https://github.com/liferay/liferay-portal-ee/compare/7.2.x...ricardocousolr:LPS-129245_72x_alt)

For more details please see [PTR-2311](https://issues.liferay.com/browse/PTR-2311).

Please let me know if you have any questions. Thanks!

/cc @achaparro.