### PR TITLE
LPS-129755 pass editingLanguageId through useSyncValue so the useEffect that cleans the value reference can be trigged

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Radio/Radio.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Radio/Radio.es.js
@@ -20,6 +20,7 @@ import {useSyncValue} from '../hooks/useSyncValue.es';
 import {setJSONArrayValue} from '../util/setters.es';
 
 const Radio = ({
+	editingLanguageId,
 	inline,
 	name,
 	onBlur,
@@ -50,7 +51,7 @@ const Radio = ({
 	const [currentValue, setCurrentValue] = useSyncValue(
 		initialValue ? initialValue : predefinedValueMemo,
 		true,
-		true
+		editingLanguageId
 	);
 
 	return (

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Radio/Radio.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Radio/Radio.es.js
@@ -20,6 +20,11 @@ import {useSyncValue} from '../hooks/useSyncValue.es';
 import {setJSONArrayValue} from '../util/setters.es';
 
 const Radio = ({
+	inline,
+	name,
+	onBlur,
+	onChange,
+	onFocus,
 	options = [
 		{
 			label: 'Option 1',
@@ -30,11 +35,6 @@ const Radio = ({
 			value: 'option2',
 		},
 	],
-	inline,
-	name,
-	onBlur,
-	onChange,
-	onFocus,
 	predefinedValue,
 	readOnly: disabled,
 	value: initialValue,


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-129755