### PR TITLE
LPS-129750 since data provider is not supported by data engine, their settings fields must not be visible in taglib

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/utils/settingsForm.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/utils/settingsForm.es.js
@@ -80,6 +80,21 @@ export const getFilteredSettingsContext = ({
 							name: generateName(name, updatedField),
 							predefinedValue: '["manual"]',
 							readOnly: true,
+							visible: false,
+						};
+					}
+
+					if (fieldName === 'ddmDataProviderInstanceId') {
+						return {
+							...updatedField,
+							visible: false,
+						};
+					}
+
+					if (fieldName === 'ddmDataProviderInstanceOutput') {
+						return {
+							...updatedField,
+							visible: false,
 						};
 					}
 


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-129750