### PR TITLE
LPS-129826 since we can have more than one level of nested fields, we need to check parent's ddmStructureId instead of the root's before allowing dragging

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/components/PageRenderer/EditorVariant.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/components/PageRenderer/EditorVariant.es.js
@@ -167,7 +167,7 @@ export const Column = ({
 						ref={(node) => {
 							if (
 								allowNestedFields &&
-								!rootParentField.ddmStructureId
+								!parentField.ddmStructureId
 							) {
 								drag(drop(node));
 							}


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-129826