### PR TITLE
LPS-129826 prevent dropping a field into a fieldset

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/hooks/useDrop.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/hooks/useDrop.es.js
@@ -114,6 +114,11 @@ const isDroppingFieldIntoFieldAndSameGroup = (
 	sourceParentField?.fieldName === targetParentField?.fieldName &&
 	targetParentField.nestedFields.length === 2;
 
+const isDroppingFieldIntoFieldset = (targetField, sourceField) =>
+	sourceField.fieldName !== targetField?.fieldName &&
+	targetField?.type === 'fieldset' &&
+	!!targetField?.ddmStructureId;
+
 const isSameField = (targetField, sourceField) =>
 	targetField && targetField.fieldName === sourceField.fieldName;
 
@@ -143,6 +148,7 @@ export const useDrop = ({
 		canDrop: (item) =>
 			!isSameField(field, item.data) &&
 			!isDroppingFieldGroupIntoField(field, item.data) &&
+			!isDroppingFieldIntoFieldset(field, item.data) &&
 			!isFieldGroupMovingIntoItself({
 				sourceIndexes: item.sourceIndexes,
 				sourceParentField: item.sourceParentField,


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-129826

**Note:** This a follow up for LPS-129826 that fix the case where the user tries to drop a field into a fieldset. Despite of the original issue being fixed in #364, we detected this other one that is very close to that, so we decided to use the same ticket to fix it since drag and drop complement each other.