### PR TITLE
LPS-129091 asset-list-service: no reason for using the classTypeId when there is no structure id to form the ddmFieldName attribute

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
@@ -319,27 +319,14 @@ public class AssetListAssetEntryProviderImpl
 						"ddmStructureFieldName",
 						DDMIndexerUtil.encodeName(
 							ddmStructure.getStructureId(),
-							ddmStructureFieldName,
+							_getFieldReference(
+								ddmStructure, ddmStructureFieldName),
 							LocaleUtil.getMostRelevantLocale()));
-				}
-				else {
-					assetEntryQuery.setAttribute(
-						"ddmStructureFieldName",
-						DDMIndexerUtil.encodeName(
-							classTypeIds[0], ddmStructureFieldName,
-							LocaleUtil.getMostRelevantLocale()));
-				}
-			}
-			else {
-				assetEntryQuery.setAttribute(
-					"ddmStructureFieldName",
-					DDMIndexerUtil.encodeName(
-						classTypeIds[0], ddmStructureFieldName,
-						LocaleUtil.getMostRelevantLocale()));
-			}
 
-			assetEntryQuery.setAttribute(
-				"ddmStructureFieldValue", ddmStructureFieldValue);
+					assetEntryQuery.setAttribute(
+						"ddmStructureFieldValue", ddmStructureFieldValue);
+				}
+			}
 		}
 
 		String orderByColumn1 = GetterUtil.getString(
@@ -650,6 +637,21 @@ public class AssetListAssetEntryProviderImpl
 		}
 
 		return dynamicAssetEntries;
+	}
+
+	private String _getFieldReference(
+		DDMStructure ddmStructure, String fieldName) {
+
+		try {
+			return ddmStructure.getFieldProperty(fieldName, "fieldReference");
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException, portalException);
+			}
+
+			return fieldName;
+		}
 	}
 
 	private long _getFirstSegmentsEntryId(

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/dynamic/data/mapping/util/DDMIndexerUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/dynamic/data/mapping/util/DDMIndexerUtil.java
@@ -28,9 +28,9 @@ import org.osgi.service.component.annotations.Reference;
 public class DDMIndexerUtil {
 
 	public static String encodeName(
-		long ddmStructureId, String name, Locale locale) {
+		long ddmStructureId, String fieldReference, Locale locale) {
 
-		return _ddmIndexer.encodeName(ddmStructureId, name, locale);
+		return _ddmIndexer.encodeName(ddmStructureId, fieldReference, locale);
 	}
 
 	@Reference(unbind = "-")

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
@@ -131,12 +131,12 @@ public class EditAssetListDisplayContext {
 	}
 
 	public String encodeName(
-		long ddmStructureId, String fieldName, Locale locale) {
+		long ddmStructureId, String fieldReference, Locale locale) {
 
 		DDMIndexer ddmIndexer = (DDMIndexer)_httpServletRequest.getAttribute(
 			AssetListWebKeys.DDM_INDEXER);
 
-		return ddmIndexer.encodeName(ddmStructureId, fieldName, locale);
+		return ddmIndexer.encodeName(ddmStructureId, fieldReference, locale);
 	}
 
 	public AssetListEntry getAssetListEntry() {

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
@@ -260,7 +260,7 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 				String orderByColumn2 = editAssetListDisplayContext.getOrderByColumn2();
 
 				for (ClassTypeField classTypeField : classTypeFields) {
-					String value = editAssetListDisplayContext.encodeName(classTypeField.getClassTypeId(), classTypeField.getName(), null);
+					String value = editAssetListDisplayContext.encodeName(classTypeField.getClassTypeId(), classTypeField.getFieldReference(), null);
 					String selectedOrderByColumn1 = StringPool.BLANK;
 					String selectedOrderByColumn2 = StringPool.BLANK;
 

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
@@ -1987,8 +1987,8 @@ public class AssetPublisherDisplayContext {
 		assetEntryQuery.setAttribute(
 			"ddmStructureFieldName",
 			_assetPublisherWebHelper.encodeName(
-				classTypeField.getClassTypeId(), getDDMStructureFieldName(),
-				locale));
+				classTypeField.getClassTypeId(),
+				classTypeField.getFieldReference(), locale));
 
 		assetEntryQuery.setAttribute(
 			"ddmStructureFieldValue", getDDMStructureFieldValue());

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/helper/AssetPublisherWebHelper.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/helper/AssetPublisherWebHelper.java
@@ -194,9 +194,9 @@ public class AssetPublisherWebHelper {
 	}
 
 	public String encodeName(
-		long ddmStructureId, String fieldName, Locale locale) {
+		long ddmStructureId, String fieldReference, Locale locale) {
 
-		return _ddmIndexer.encodeName(ddmStructureId, fieldName, locale);
+		return _ddmIndexer.encodeName(ddmStructureId, fieldReference, locale);
 	}
 
 	public String[] filterAssetTagNames(long groupId, String[] assetTagNames) {

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -316,7 +316,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 			String orderByColumn2 = assetPublisherDisplayContext.getOrderByColumn2();
 
 			for (ClassTypeField classTypeField : classTypeFields) {
-				String value = assetPublisherWebHelper.encodeName(classTypeField.getClassTypeId(), classTypeField.getName(), null);
+				String value = assetPublisherWebHelper.encodeName(classTypeField.getClassTypeId(), classTypeField.getFieldReference(), null);
 				String selectedOrderByColumn1 = StringPool.BLANK;
 				String selectedOrderByColumn2 = StringPool.BLANK;
 

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataRecordResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataRecordResourceImpl.java
@@ -437,7 +437,9 @@ public class DataRecordResourceImpl
 
 				fieldBooleanFilter.add(
 					_ddmIndexer.createFieldValueQueryFilter(
-						ddmStructure, fieldName,
+						ddmStructure,
+						ddmStructure.getFieldProperty(
+							fieldName, "fieldReference"),
 						contextAcceptLanguage.getPreferredLocale(), value),
 					BooleanClauseOccur.SHOULD);
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Mapping API
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.api
-Bundle-Version: 9.0.1
+Bundle-Version: 9.1.0
 Export-Package:\
 	com.liferay.dynamic.data.mapping.annotations,\
 	com.liferay.dynamic.data.mapping.configuration,\

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStructure.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStructure.java
@@ -71,6 +71,9 @@ public interface DDMStructure extends DDMStructureModel, PersistedModel {
 	public DDMFormField getDDMFormField(String fieldName)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
+	public DDMFormField getDDMFormFieldByFieldReference(String fieldReference)
+		throws com.liferay.portal.kernel.exception.PortalException;
+
 	public java.util.List<DDMFormField> getDDMFormFields(
 		boolean includeTransientFields);
 
@@ -91,6 +94,10 @@ public interface DDMStructure extends DDMStructureModel, PersistedModel {
 	public java.util.Set<String> getFieldNames();
 
 	public String getFieldProperty(String fieldName, String property)
+		throws com.liferay.portal.kernel.exception.PortalException;
+
+	public String getFieldPropertyByFieldReference(
+			String fieldReference, String property)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	public boolean getFieldRepeatable(String fieldName)
@@ -142,6 +149,8 @@ public interface DDMStructure extends DDMStructureModel, PersistedModel {
 		String webDAVToken);
 
 	public boolean hasField(String fieldName);
+
+	public boolean hasFieldByFieldReference(String fieldReference);
 
 	public boolean isFieldRepeatable(String fieldName)
 		throws com.liferay.portal.kernel.exception.PortalException;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStructureWrapper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStructureWrapper.java
@@ -293,6 +293,13 @@ public class DDMStructureWrapper
 	}
 
 	@Override
+	public DDMFormField getDDMFormFieldByFieldReference(String fieldReference)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return model.getDDMFormFieldByFieldReference(fieldReference);
+	}
+
+	@Override
 	public java.util.List<DDMFormField> getDDMFormFields(
 		boolean includeTransientFields) {
 
@@ -433,6 +440,14 @@ public class DDMStructureWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return model.getFieldProperty(fieldName, property);
+	}
+
+	@Override
+	public String getFieldPropertyByFieldReference(
+			String fieldReference, String property)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return model.getFieldPropertyByFieldReference(fieldReference, property);
 	}
 
 	@Override
@@ -792,6 +807,11 @@ public class DDMStructureWrapper
 	@Override
 	public boolean hasField(String fieldName) {
 		return model.hasField(fieldName);
+	}
+
+	@Override
+	public boolean hasFieldByFieldReference(String fieldReference) {
+		return model.hasFieldByFieldReference(fieldReference);
 	}
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMIndexer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMIndexer.java
@@ -53,7 +53,7 @@ public interface DDMIndexer {
 		DDMFormValues ddmFormValues);
 
 	public Sort createDDMStructureFieldSort(
-			DDMStructure ddmStructure, String fieldName, Locale locale,
+			DDMStructure ddmStructure, String fieldReference, Locale locale,
 			SortOrder sortOrder)
 		throws PortalException;
 
@@ -62,7 +62,7 @@ public interface DDMIndexer {
 		throws PortalException;
 
 	public QueryFilter createFieldValueQueryFilter(
-			DDMStructure ddmStructure, String fieldName, Locale locale,
+			DDMStructure ddmStructure, String fieldReference, Locale locale,
 			Serializable value)
 		throws Exception;
 
@@ -71,10 +71,10 @@ public interface DDMIndexer {
 			Locale locale)
 		throws Exception;
 
-	public String encodeName(long ddmStructureId, String fieldName);
+	public String encodeName(long ddmStructureId, String fieldReference);
 
 	public String encodeName(
-		long ddmStructureId, String fieldName, Locale locale);
+		long ddmStructureId, String fieldReference, Locale locale);
 
 	public String extractIndexableAttributes(
 		DDMStructure ddmStructure, DDMFormValues ddmFormValues, Locale locale);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/model/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/model/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dynamic/data/mapping/DDMStructureField.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dynamic/data/mapping/DDMStructureField.java
@@ -33,9 +33,8 @@ public class DDMStructureField {
 			ddmStructureParts[3], StringPool.UNDERLINE);
 
 		return new DDMStructureField(
-			ddmStructureParts[2], ddmStructureParts[1],
-			ddmFieldParts[1] + "_" + ddmFieldParts[2], ddmFieldParts[0],
-			ddmFieldParts[3]);
+			ddmStructureParts[2], ddmFieldParts[0], ddmStructureParts[1],
+			ddmFieldParts[1] + "_" + ddmFieldParts[2], ddmFieldParts[3]);
 	}
 
 	public static String getNestedFieldName() {
@@ -48,8 +47,8 @@ public class DDMStructureField {
 		return StringBundler.concat(
 			DDMIndexer.DDM_FIELD_PREFIX, _indexType,
 			DDMIndexer.DDM_FIELD_SEPARATOR, _ddmStructureId,
-			DDMIndexer.DDM_FIELD_SEPARATOR, _name, StringPool.UNDERLINE,
-			_locale);
+			DDMIndexer.DDM_FIELD_SEPARATOR, _fieldReference,
+			StringPool.UNDERLINE, _locale);
 	}
 
 	public String getDDMStructureNestedFieldName() {
@@ -74,20 +73,20 @@ public class DDMStructureField {
 	}
 
 	private DDMStructureField(
-		String ddmStructureId, String indexType, String locale, String name,
-		String type) {
+		String ddmStructureId, String fieldReference, String indexType,
+		String locale, String type) {
 
 		_ddmStructureId = ddmStructureId;
+		_fieldReference = fieldReference;
 		_indexType = indexType;
 		_locale = locale;
-		_name = name;
 		_type = type;
 	}
 
 	private final String _ddmStructureId;
+	private final String _fieldReference;
 	private final String _indexType;
 	private final String _locale;
-	private final String _name;
 	private final String _type;
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/EntityFieldsProvider.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/EntityFieldsProvider.java
@@ -85,8 +85,8 @@ public class EntityFieldsProvider {
 			return new BooleanEntityField(
 				ddmFormField.getFieldReference(),
 				locale -> _toFilterableOrSortableFieldName(
-					ddmStructure.getStructureId(), ddmFormField.getName(),
-					locale, "String"));
+					ddmStructure.getStructureId(),
+					ddmFormField.getFieldReference(), locale, "String"));
 		}
 		else if (Objects.equals(
 					ddmFormField.getDataType(), FieldConstants.DATE)) {
@@ -94,11 +94,11 @@ public class EntityFieldsProvider {
 			return new DateEntityField(
 				ddmFormField.getFieldReference(),
 				locale -> _toFilterableOrSortableFieldName(
-					ddmStructure.getStructureId(), ddmFormField.getName(),
-					locale, "String"),
+					ddmStructure.getStructureId(),
+					ddmFormField.getFieldReference(), locale, "String"),
 				locale -> _toFilterableOrSortableFieldName(
-					ddmStructure.getStructureId(), ddmFormField.getName(),
-					locale, "String"),
+					ddmStructure.getStructureId(),
+					ddmFormField.getFieldReference(), locale, "String"),
 				this::_toFieldValue);
 		}
 		else if (Objects.equals(
@@ -109,8 +109,8 @@ public class EntityFieldsProvider {
 			return new DoubleEntityField(
 				ddmFormField.getFieldReference(),
 				locale -> _toFilterableOrSortableFieldName(
-					ddmStructure.getStructureId(), ddmFormField.getName(),
-					locale, "Number"));
+					ddmStructure.getStructureId(),
+					ddmFormField.getFieldReference(), locale, "Number"));
 		}
 		else if (Objects.equals(
 					ddmFormField.getDataType(), FieldConstants.INTEGER) ||
@@ -120,8 +120,8 @@ public class EntityFieldsProvider {
 			return new IntegerEntityField(
 				ddmFormField.getFieldReference(),
 				locale -> _toFilterableOrSortableFieldName(
-					ddmStructure.getStructureId(), ddmFormField.getName(),
-					locale, "Number"));
+					ddmStructure.getStructureId(),
+					ddmFormField.getFieldReference(), locale, "Number"));
 		}
 		else if (Objects.equals(
 					ddmFormField.getType(), DDMFormFieldType.RADIO) ||
@@ -132,8 +132,8 @@ public class EntityFieldsProvider {
 			return new StringEntityField(
 				ddmFormField.getFieldReference(),
 				locale -> _toFilterableOrSortableFieldName(
-					ddmStructure.getStructureId(), ddmFormField.getName(),
-					locale, "String"));
+					ddmStructure.getStructureId(),
+					ddmFormField.getFieldReference(), locale, "String"));
 		}
 
 		return null;
@@ -157,11 +157,12 @@ public class EntityFieldsProvider {
 	}
 
 	private String _toFilterableOrSortableFieldName(
-		long ddmStructureId, String fieldName, Locale locale, String type) {
+		long ddmStructureId, String fieldReference, Locale locale,
+		String type) {
 
 		return Field.getSortableFieldName(
 			StringBundler.concat(
-				_ddmIndexer.encodeName(ddmStructureId, fieldName, locale),
+				_ddmIndexer.encodeName(ddmStructureId, fieldReference, locale),
 				StringPool.UNDERLINE, type));
 	}
 

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 10.0.3
+Bundle-Version: 10.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.test.*,\

--- a/portal-kernel/src/com/liferay/asset/kernel/model/ClassTypeField.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/ClassTypeField.java
@@ -20,6 +20,17 @@ package com.liferay.asset.kernel.model;
 public class ClassTypeField {
 
 	public ClassTypeField(
+		long classTypeId, String fieldReference, String label, String name,
+		String type) {
+
+		_classTypeId = classTypeId;
+		_fieldReference = fieldReference;
+		_label = label;
+		_name = name;
+		_type = type;
+	}
+
+	public ClassTypeField(
 		String label, String name, String type, long classTypeId) {
 
 		_label = label;
@@ -30,6 +41,10 @@ public class ClassTypeField {
 
 	public long getClassTypeId() {
 		return _classTypeId;
+	}
+
+	public String getFieldReference() {
+		return _fieldReference;
 	}
 
 	public String getLabel() {
@@ -45,6 +60,7 @@ public class ClassTypeField {
 	}
 
 	private final long _classTypeId;
+	private String _fieldReference;
 	private final String _label;
 	private final String _name;
 	private final String _type;

--- a/portal-kernel/src/com/liferay/asset/kernel/model/DDMStructureClassType.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/DDMStructureClassType.java
@@ -108,9 +108,10 @@ public class DDMStructureClassType implements ClassType {
 
 			classTypeFields.add(
 				new ClassTypeField(
+					ddmStructure.getStructureId(),
+					ddmFormField.getFieldReference(),
 					label.getString(LocaleUtil.fromLanguageId(_languageId)),
-					ddmFormField.getName(), type,
-					ddmStructure.getStructureId()));
+					ddmFormField.getName(), type));
 		}
 
 		return classTypeFields;

--- a/portal-kernel/src/com/liferay/asset/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/portal-kernel/src/com/liferay/dynamic/data/mapping/kernel/DDMFormField.java
+++ b/portal-kernel/src/com/liferay/dynamic/data/mapping/kernel/DDMFormField.java
@@ -63,6 +63,10 @@ public class DDMFormField implements Serializable {
 		return MapUtil.getString(_properties, "fieldNamespace");
 	}
 
+	public String getFieldReference() {
+		return MapUtil.getString(_properties, "fieldReference");
+	}
+
 	public String getIndexType() {
 		return MapUtil.getString(_properties, "indexType");
 	}
@@ -170,6 +174,10 @@ public class DDMFormField implements Serializable {
 
 	public void setFieldNamespace(String fieldNamespace) {
 		_properties.put("fieldNamespace", fieldNamespace);
+	}
+
+	public void setFieldReference(String fieldReference) {
+		_properties.put("fieldReference", fieldReference);
 	}
 
 	public void setIndexType(String indexType) {

--- a/portal-kernel/src/com/liferay/dynamic/data/mapping/kernel/packageinfo
+++ b/portal-kernel/src/com/liferay/dynamic/data/mapping/kernel/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0


### PR DESCRIPTION
Related ticket: https://issues.liferay.com/browse/LPS-129091