### PR TITLE
LPS-130068 since dataSourceType field is not visible anymore, we need to update options rule so we guarantee they are visible even if dataSourceType is not

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/utils/settingsForm.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/utils/settingsForm.es.js
@@ -80,6 +80,7 @@ export const getFilteredSettingsContext = ({
 							name: generateName(name, updatedField),
 							predefinedValue: '["manual"]',
 							readOnly: true,
+							visibilityExpression: 'FALSE',
 							visible: false,
 						};
 					}
@@ -87,6 +88,7 @@ export const getFilteredSettingsContext = ({
 					if (fieldName === 'ddmDataProviderInstanceId') {
 						return {
 							...updatedField,
+							visibilityExpression: 'FALSE',
 							visible: false,
 						};
 					}
@@ -94,6 +96,7 @@ export const getFilteredSettingsContext = ({
 					if (fieldName === 'ddmDataProviderInstanceOutput') {
 						return {
 							...updatedField,
+							visibilityExpression: 'FALSE',
 							visible: false,
 						};
 					}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTypeSettings.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTypeSettings.java
@@ -43,7 +43,7 @@ import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 				"setRequired('options', contains(getValue('dataSourceType'), \"manual\"))",
 				"setVisible('ddmDataProviderInstanceId', contains(getValue('dataSourceType'), \"data-provider\"))",
 				"setVisible('ddmDataProviderInstanceOutput', contains(getValue('dataSourceType'), \"data-provider\"))",
-				"setVisible('options', contains(getValue('dataSourceType'), \"manual\"))",
+				"setVisible('options', (isEmpty(getValue('dataSourceType')) OR (contains(getValue('dataSourceType'), \"manual\"))))",
 				"setVisible('predefinedValue', contains(getValue('dataSourceType'), \"manual\"))",
 				"setVisible('validation', false)"
 			},

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTypeSettingsTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTypeSettingsTest.java
@@ -178,8 +178,10 @@ public class SelectDDMFormFieldTypeSettingsTest
 		Assert.assertTrue(
 			actions.toString(),
 			actions.contains(
-				"setVisible('options', contains(getValue('dataSourceType'), " +
-					"\"manual\"))"));
+				StringBundler.concat(
+					"setVisible('options', ",
+					"(isEmpty(getValue('dataSourceType')) OR ",
+					"(contains(getValue('dataSourceType'), \"manual\"))))")));
 		Assert.assertTrue(
 			actions.toString(),
 			actions.contains(


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-130068