### PR TITLE
LRQA-66228 Improve test to make sure the list has 2 structures and remove test from quarantine

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureLocalServiceTest.java
@@ -73,7 +73,6 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -501,7 +500,6 @@ public class DDMStructureLocalServiceTest extends BaseDDMServiceTestCase {
 		Assert.assertEquals(structures.toString(), 1, structures.size());
 	}
 
-	@Ignore
 	@Test
 	public void testSearchByKeywords1() throws Exception {
 		DDMStructure structure = addStructure(_classNameId, "Events");
@@ -514,6 +512,7 @@ public class DDMStructureLocalServiceTest extends BaseDDMServiceTestCase {
 			WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, new StructureIdComparator(true));
 
+		Assert.assertEquals(structures.toString(), 2, structures.size());
 		Assert.assertEquals("Events", getStructureName(structures.get(0)));
 		Assert.assertEquals("Event", getStructureName(structures.get(1)));
 	}


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LRQA-66228

We could't simulate the flaky test locally and even in our Github repository running Liferay tests in CI, so we decided to improve the test to make sure the list has 2 structures before assert them by indexes. We suppose that sometimes the test is inserting just one structure.