### PR TITLE
LPS 130868

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/java/com/liferay/data/engine/taglib/internal/content/type/DefaultDataDefinitionContentType.java
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/java/com/liferay/data/engine/taglib/internal/content/type/DefaultDataDefinitionContentType.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.data.engine.taglib.internal.content.type;
+
+import com.liferay.data.engine.content.type.DataDefinitionContentType;
+import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.portal.kernel.model.ClassedModel;
+import com.liferay.portal.kernel.util.Portal;
+
+import java.io.Serializable;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Rodrigo Paulino
+ */
+@Component(
+	immediate = true, property = "content.type=default",
+	service = DataDefinitionContentType.class
+)
+public class DefaultDataDefinitionContentType
+	implements DataDefinitionContentType {
+
+	@Override
+	public long getClassNameId() {
+		return _portal.getClassNameId(DataDefinition.class);
+	}
+
+	public class DataDefinition implements ClassedModel, Serializable {
+
+		@Override
+		public ExpandoBridge getExpandoBridge() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Class<?> getModelClass() {
+			return DataDefinition.class;
+		}
+
+		@Override
+		public String getModelClassName() {
+			return DataDefinition.class.getName();
+		}
+
+		@Override
+		public Serializable getPrimaryKeyObj() {
+			return _dataDefinitionId;
+		}
+
+		@Override
+		public void setPrimaryKeyObj(Serializable primaryKeyObj) {
+			_dataDefinitionId = (long)primaryKeyObj;
+		}
+
+		private long _dataDefinitionId;
+
+	}
+
+	@Reference
+	private Portal _portal;
+
+}


### PR DESCRIPTION
- LRQA-66559 Add missing part
- LRQA-64445 Fix ViewPortletBoundaries test
- LRQA-66657 CAT tests
- LRQA-66659 Unquarantine test since bug is fixed
- LRQA-66636 Update paths for the translations field
- LRQA-66636 Update macro to use a suitable way to assert
- LPS-130424 Add missing parameters
- LPS-130424 Modify macro to assert Grid field option unchecked
- LPS-130424 Modify macro to assert template and related asset
- LPS-130424 Modify case to cancel reset and reset default values in imported structure with all fields
- LPS-130424 Reinitialize liferay events before open modal
- LPS-130424 Modify case to cancel reset and reset default values in structure with all fields
- COMMERCE-6030 Adding AddAnAttachment Test
- COMMERCE-6030 SF
- COMMERCE-5806 Adding UseSkuSearchBarAndPagination Test
- COMMERCE-5806 SF
- COMMERCE-6065 Adding AddAPreExistingProductGroup Test
- COMMERCE-6065 SF
- COMMERCE-6105 Adding EditMoneyOrderPaymentMethod Test
- COMMERCE-6105 SF
- COMMERCE-6107 Adding EditMercanetPaymentMethod Test
- COMMERCE-6107 SF
- LRDOCS-9336 Groovy is the only scripting module in Foundation
- LRQA-66067 Give ifSet condition to addEntryExternalURL
- LRQA-66067 Add CanAddHyperlinkToExistingText test
- LRQA-66067 Refactor test with JSON, and new macro and path
- LRQA-66669 Modify case to adapt to the expected behavior
- LRQA-66656 Promote test to an acceptance test
- LPS-130594 Use a Registrator to load into saml-web a ResourceBundle for any available language
- LPS-130594 Rename
- LPS-130594 Rename
- LPS-130594 Inline, Hugo SF - we should make a HashMapDictionary builder
- LPS-130594 This is never null
- LPS-130594 auto SF
- LPS-130594 Rename
- LPS-130070 Show error message when publishing a journal article with a default language title blank
- LPS-126140 Modify case to assert input field still contains the invalid email after pressing enter
- LPS-130233 Wait for element instead of using hard pause
- LPS-130233 Declare key variables right before they are used
- LPS-130233 Add macro to navigate to specific blog entry
- LPS-130233 Apply new navigation to site page entries
- LPS-130233 Remove redundant test
- LPS-130233 Remove add test in favor of edit
- LPS-130233 Add macro to navigate to blogs form without depending on UI
- LPS-130233 Apply to site and page tests excluding staging
- LPS-130233 Remove stalls
- LPS-130233 Declare explicitly and only before needed
- LPS-130233 Remove assertion since this is covered in PGBlogs#AddCustomURL
- LPS-130233 Remove test
- LPS-130233 Assert automatic URL in custom URL test
- LPS-130233 Add through JSON
- LPS-130233 Remove test since we already have cases that test within limits
- LPS-130233 Add data through JSON
- LPS-130233 Check that characters are not escaped through UI and account for opposite cases as well
- LPS-130233 Reorder assertions and declarations
- LPS-130233 Remove additional assertions since there are already checks for them
- LPS-130233 Describe steps at a high level
- LPS-130233 Fix declaration order
- LPS-130233 SF
- LPS-130233 Declare variables inside macro
- LPS-130233 Remove unnecessary assertion
- LPS-130233 Remove test since it duplicates PGBlogs#CannotAddDuplicateCustomURL
- LPS-130233 Remove viewing the entry since the focus is deletion
- LPS-130233 Just use two entries because we are testing the same thing with three
- LPS-130233 Add entries via JSON instead
- LPS-130233 Just edit two instead of three like before
- LPS-130233 Remove test since it is covered by PGBlogs#CanDeleteMultipleEntriesSequentially
- LPS-130233 Remove macros since the previous or prior step already performs the navigation
- LPS-130233 Simplify
- LPS-130233 Make content completely unique from title to not confound search results
- LPS-130233 Apply same logic in different test
- LPS-130233 Reduce fluff in search queries
- LPS-130233 Remove unnecessary step
- LPS-130233 Use JSON to add and configure assets
- LPS-130233 Add missing test priority
- LPS-130233 Summarize test steps with task
- LPS-130233 Remove pause
- LPS-130233 Summary test steps with tasks
- LPS-130233 Remove test
- LPS-130233 Remove unnecessary steps
- LPS-130233 Remove pause
- LPS-130233 Remove test
- LPS-130233 Update test names
- LPS-130233 SF
- LPS-130233 Use JSON to add blog
- LPS-130233 Move test to widget-specific test file
- LPS-130233 Remove pause
- LPS-130233 Move to CPBlogs because we have cover image tests there
- LPS-130233 Remove test since this is covered by CPBlogs#DeleteBlogsEntries
- LPS-130233 Remove pause
- LPS-130233 Combine tests to CPBlogs#CanDeleteDraft
- LPS-130233 Rely on backend
- LPS-130233 Remove assertions since they are already performed in other tests
- LPS-130233 Remove test because it is covered by RecycleBin#RecycleBinBlogs
- LPS-130233 Focus on the main assertion
- LPS-130233 Summarize test
- LPS-130233 Remove steps covered in AssetPublisherShowFullContent#AddAssetTypesViaAPAndAddRespectivePortletsToSamePage
- LPS-130233 Remove test covered by CPBlogs#CanSearchForDMImagesInItemSelector
- LPS-130233 Use JSON
- LPS-130233 Remove test
- LPS-130233 Remove test covered by BlogsUsecase#ViewBlogsEntryAsPublishedViaAP
- LPS-130233 Use JSON
- LPS-130233 Replace with existing macro
- LPS-130233 Use JSON
- LPS-130233 SF
- LPS-130233 Remove test
- LPS-130233 Apply same flow from PGBlogs#CanAddTitleWithoutEscapingCharacters
- LPS-130233 Remove test covered by PGBlogs#CanAddEntryWithSubtitle
- LPS-130233 Keep only the admin test
- LPS-130233 Focus on main assertions
- LPS-130233 Remove test covered by CPBlogs#CanPublishDraftEntry
- LPS-130233 Keep only one auto draft test
- LPS-130233 Simplify search tests
- LPS-130233 Remove pauses
- LPS-130233 Declare variable inside macro
- LPS-130233 Move tests to item selector
- LPS-130233 Rework test case
- LPS-130233 SF
- LPS-130233 Auto SF
- LPS-130233 Apply new names to test properties as well
- LPS-130233 Remove unnecessary steps
- LPS-130233 Move tests to widget file
- LPS-130233 Mark tests that require follow-up
- LPS-130233 Add missing declarations
- LPS-130233 Add refresh since tests are too quick
- LPS-130233 Change to add through UI since JSON will outright deny the request
- LPS-129121 Add test for the multiple upload
- LPS-129121 Add test for the blog auto tag
- LPS-129124 Update macro for editing the document type
- LPS-129124 Add path for the dropdown toggle button
- LPS-129142 Update macro for selecting image from blog images
- LPS-129142 Add test for the blogs cover image
- LPS-129137 Add path for the remove supported mime type icon
- LPS-129137 Add test for the document and media
- LPS-129208 Add macro for view no comments on page
- LPS-129208 Add test for validate comment only appear under the respective blog
- LPS-129122 Add macro for viewing file size by version
- LPS-129122 Add test for the document file size
- LPS-129122 Add paths for the document toolbar item
- LPS-129133 Add test for the document type
- LPS-129136 Update setup can login by link
- LPS-129136 Update macro for adding multiple mentions
- LPS-129136 Add test for the thread mentions
- LPS-129136 Update tests to use the faster navigation
- LPS-129134 Update macro for select embed image when add WC via widget
- LPS-129134 Add test for site admin user can select image from global site
- LPS-129114 Add macro for add user page
- LPS-129114 Add test for view no private site as non-site member via calendar widget
- LPS-129129 Update macro for edit description
- LPS-129129 Add test for republish document after checkout again
- LPS-129138 Add macros for add shortcut and set root folder
- LPS-129138 Add test for create shortcut using file from another site after set root folder
- LPS-129423 Archive the Hello World portlet
- LPS-129423 Remove CSS for the Hello World portlet from the Classic Theme
- LPS-129423 Update build.properties
- LPS-129423 Update modules.properties
- LPS-129423 Remove usages of hello-world-web
- LPS-129423 Clean up hello world portlet data
- LPS-129423 Add test
- LPS-129423 Build lang
- LPS-129423 Move the hello-world-web to archived. We don't need the parent directory.
- LPS-129423 Remove assertion
- LPS-129423 Change to Hello Velocity widget
- LPS-129423 Make sure the Hello Velocity portlet is added
- LPS-129423 Update the test use a different localized portlet
- LPS-129423 Confirm the page is loaded instead view the welcome page
- LPS-129423 Remove the hello world related path
- LPS-129423 Use the widget bundled in slim bundle
- LRQA-66610 Avoid issue in LPS-130588 in test
- LPS-130431 Migrate cases related to Contents panel to single file
- LPS-130468 Merge cases to reduce duplicate test
- LPS-130468 Modify macros to define portalInstanceName
- LPS-130468 Modify macro to define localhost as portalInstanceName
- LRAC-7713 using clay:icon taglib instead of liferay-ui:icon
- LPS-130393 We must avoid to create companies per test method. This solves the OOM error for this specific case (although it can exist a memory leak in the removal of objects after tests) and gets a 95% reduction test time
- LPS-124423 Add staging process for fields of type collectionSelector
- LPS-130482 Make sure to update the lookAndFeel for the layoutRevision as well, otherwise changes won't show in live.
- LPS-130482 Import theme after we add/update the imported layout, otherwise we throw exceptions if the imported layout doesn't exist yet.
- COMMERCE-5803 Add test to check product sorting by name and date
- COMMERCE-5803 Add two macros to assert an entry and to sort fields
- COMMERCE-5803 Add test to check product sorting by name and date
- COMMERCE-5808 adding EditAProduct test
- COMMERCE-5807 Add test to edit SKU then delete SKU
- COMMERCE-5803 Remove ignore
- COMMERCE-5803 Remove unused macro and change locator
- LPS-129887 put fileName search team outside check of the keyword
- LPS-129887 add a BooleanQuery to search on the filename by match and prefix_match for the cases when filename and title are different, or filename is different to "title plus extension"
- LPS-129887 take into account the search of literal strings on the search of the fileName
- LPS-129887 add literal search to test
- LPS-129887 add test when filename is different than title
- LPS-129887 Sort
- LPS-119066 Add tests for LayoutReportsDataProvider
- LPS-119066 New LayoutReportsDataProviderException exception.
- LPS-119066 Add new POJO LayoutReportsIssue.
- LPS-119066 Add tests
- LPS-119066 New method getLayoutReportsIssues that return the list of LayoutReportsIssues found for a given url.
- LPS-119066 BuildLang.
- LPS-130117 Make Calendar with view details permission to default calendar when this is null
- LPS-130685 Passing typeSettingsProperties on layout creation from template.
- LPS-130685 follow order in service usage
- LPS-129264 Add util class to temporarily replace props values
- LPS-129264 Replace usages
- LPS-129264 Remove duplicates
- LPS-129264 Disable bulk mode so that messages are localized
- LPS-129264 Baseline
- LPS-129264 Allow portal-test to access portal-impl, since now portal-kernal is in portal web scope anymore.
- LPS-129264 Does not need to be a module, just another util.
- LPS-129264 add a line break where order matters
- LPS-130666 Check for add permission
- Revert "7.4.0 GA1 Release Apps: account, adaptive-media, address, alloy, analytics, announcements, app-builder, application-list, asset, batch-engine, bean-portlet, blogs, bulk, calendar, captcha, change-tracking, changeset, comment, commerce, configuration-admin, connected-app, contacts, content-dashboard, data-cleanup, data-engine, depot, dispatch, document-library-opener, document-library, dynamic-data-lists, dynamic-data-mapping, expando, export-import, external-reference, flags, fragment, friendly-url, frontend-css, frontend-editor, frontend-js, frontend-taglib, frontend-theme, frontend-token, gogo-shell, headless, hello-world, iframe, image-uploader, imageio-plugins, info, invitation, item-selector, journal, knowledge-base, layout, license-manager, login, map, mentions, message-boards, microsoft-translator, mobile-device-rules, monitoring, nested-portlets, notifications, oauth2-provider, organizations, password-policies-admin, petra, plugins-admin, portal-background-task, portal-cache, portal-configuration, portal-instances, portal-language, portal-lock, portal-mobile-device-recognition, portal-odata, portal-osgi-debug, portal-portlet-bridge, portal-relationship, portal-remote, portal-reports-engine, portal-rules-engine, portal-scheduler, portal-scripting, portal-search-elasticsearch7, portal-search, portal-security-audit, portal-security-sso, portal-security, portal-settings, portal-store, portal-template, portal-url-builder, portal-validation, portal-vulcan, portal-workflow, portal, portlet-configuration, portlet-dependency-factory, portlet-display-template, product-navigation, questions, ratings, reading-time, redirect, remote-app, roles, rss, screens, segments, server, sharing, site-navigation, site, social, staging, style-book, subscription, text-localizer, translation, trash, upload, user-associated-data, user-groups-admin, users-admin, view-count, websocket, wiki, xstream"
- artifact:ignore portal-impl 7.0.0 prep next
- artifact:ignore portal-impl 7.0.0 releng
- LPS-130274 Check column existance to avoid duplicate column errors in case upgrade step failed before.
- LPS-130274 Use appropiate table version for fallback recreation mechanism.
- artifact:ignore portal-kernel 10.5.0 prep next
- artifact:ignore portal-kernel 10.5.0 releng
- artifact:ignore portal-test 9.2.0 prep next
- artifact:ignore portal-test 9.2.0 releng
- artifact:ignore portal-web 5.0.27 prep next
- artifact:ignore portal-web 5.0.27 releng
- artifact:ignore util-slf4j 6.0.2 prep next
- artifact:ignore util-slf4j 6.0.2 releng
- build.gradle auto SF
- LPS-129959 Do not create one company per test. This solves the OOM error and improve the performance of the test
- LPS-129959 We need to call InitCompany since we have to register the portlet category for this company so the kaleo portlet can be registered too
- artifact:ignore petra-process 5.0.1 change log
- artifact:ignore petra-process 5.0.1 prep next
- artifact:ignore petra-process 5.0.1 artifact properties
- build.gradle auto SF
- artifact:ignore adaptive-media-api 6.0.1 change log
- artifact:ignore adaptive-media-api 6.0.1 prep next
- artifact:ignore adaptive-media-api 6.0.1 artifact properties
- artifact:ignore chat-service 6.0.3 change log
- artifact:ignore chat-service 6.0.3 prep next
- artifact:ignore chat-service 6.0.3 artifact properties
- artifact:ignore chat-web 5.0.2 change log
- artifact:ignore chat-web 5.0.2 prep next
- artifact:ignore chat-web 5.0.2 artifact properties
- artifact:ignore document-library-file-rank-service 4.0.3 change log
- artifact:ignore document-library-file-rank-service 4.0.3 prep next
- artifact:ignore document-library-file-rank-service 4.0.3 artifact properties
- artifact:ignore hello-world-web 6.0.2 change log
- artifact:ignore hello-world-web 6.0.2 prep next
- artifact:ignore hello-world-web 6.0.2 artifact properties
- artifact:ignore html-preview-service 4.0.2 change log
- artifact:ignore html-preview-service 4.0.2 prep next
- artifact:ignore html-preview-service 4.0.2 artifact properties
- artifact:ignore recent-documents-web 6.0.2 change log
- artifact:ignore recent-documents-web 6.0.2 prep next
- artifact:ignore recent-documents-web 6.0.2 artifact properties
- artifact:ignore sync-service 5.0.3 change log
- artifact:ignore sync-service 5.0.3 prep next
- artifact:ignore sync-service 5.0.3 artifact properties
- artifact:ignore web-form-web 5.0.3 change log
- artifact:ignore web-form-web 5.0.3 prep next
- artifact:ignore web-form-web 5.0.3 artifact properties
- artifact:ignore wysiwyg-web 5.0.2 change log
- artifact:ignore wysiwyg-web 5.0.2 prep next
- artifact:ignore wysiwyg-web 5.0.2 artifact properties
- artifact:ignore asset-auto-tagger-service 3.0.3 change log
- artifact:ignore asset-auto-tagger-service 3.0.3 prep next
- artifact:ignore asset-auto-tagger-service 3.0.3 artifact properties
- artifact:ignore asset-category-property-service 4.0.2 change log
- artifact:ignore asset-category-property-service 4.0.2 prep next
- artifact:ignore asset-category-property-service 4.0.2 artifact properties
- artifact:ignore asset-display-page-api 7.0.2 change log
- artifact:ignore asset-display-page-api 7.0.2 prep next
- artifact:ignore asset-display-page-api 7.0.2 artifact properties
- artifact:ignore asset-entry-rel-service 4.0.2 change log
- artifact:ignore asset-entry-rel-service 4.0.2 prep next
- artifact:ignore asset-entry-rel-service 4.0.2 artifact properties
- artifact:ignore asset-publisher-layout-prototype 5.0.2 change log
- artifact:ignore asset-publisher-layout-prototype 5.0.2 prep next
- artifact:ignore asset-publisher-layout-prototype 5.0.2 artifact properties
- artifact:ignore asset-tags-compiler-web 6.0.2 change log
- artifact:ignore asset-tags-compiler-web 6.0.2 prep next
- artifact:ignore asset-tags-compiler-web 6.0.2 artifact properties
- artifact:ignore blogs-layout-prototype 6.0.2 change log
- artifact:ignore blogs-layout-prototype 6.0.2 prep next
- artifact:ignore blogs-layout-prototype 6.0.2 artifact properties
- artifact:ignore captcha-impl 4.0.1 change log
- artifact:ignore captcha-impl 4.0.1 prep next
- artifact:ignore captcha-impl 4.0.1 artifact properties
- artifact:ignore changeset-service 4.0.2 change log
- artifact:ignore changeset-service 4.0.2 prep next
- artifact:ignore changeset-service 4.0.2 artifact properties
- artifact:ignore commerce-notification-service 4.0.4 change log
- artifact:ignore commerce-notification-service 4.0.4 prep next
- artifact:ignore commerce-notification-service 4.0.4 artifact properties
- artifact:ignore commerce-product-taglib 4.0.2 change log
- artifact:ignore commerce-product-taglib 4.0.2 prep next
- artifact:ignore commerce-product-taglib 4.0.2 artifact properties
- artifact:ignore commerce-wish-list-service 4.0.3 change log
- artifact:ignore commerce-wish-list-service 4.0.3 prep next
- artifact:ignore commerce-wish-list-service 4.0.3 artifact properties
- artifact:ignore data-cleanup 2.0.2 change log
- artifact:ignore data-cleanup 2.0.2 prep next
- artifact:ignore data-cleanup 2.0.2 artifact properties
- artifact:ignore document-library-content-service 4.0.2 change log
- artifact:ignore document-library-content-service 4.0.2 prep next
- artifact:ignore document-library-content-service 4.0.2 artifact properties
- artifact:ignore document-library-layout-set-prototype 6.0.1 change log
- artifact:ignore document-library-layout-set-prototype 6.0.1 prep next
- artifact:ignore document-library-layout-set-prototype 6.0.1 artifact properties
- artifact:ignore document-library-repository-authorization-api 5.1.0 change log
- artifact:ignore document-library-repository-authorization-api 5.1.0 prep next
- artifact:ignore document-library-repository-authorization-api 5.1.0 artifact properties
- artifact:ignore dynamic-data-mapping-lang 6.0.10 change log
- artifact:ignore dynamic-data-mapping-lang 6.0.10 prep next
- artifact:ignore dynamic-data-mapping-lang 6.0.10 artifact properties
- artifact:ignore friendly-url-service 4.0.2 change log
- artifact:ignore friendly-url-service 4.0.2 prep next
- artifact:ignore friendly-url-service 4.0.2 artifact properties
- artifact:ignore frontend-js-minifier 4.0.3 change log
- artifact:ignore frontend-js-minifier 4.0.3 prep next
- artifact:ignore frontend-js-minifier 4.0.3 artifact properties
- artifact:ignore frontend-js-spa-web 5.0.5 change log
- artifact:ignore frontend-js-spa-web 5.0.5 prep next
- artifact:ignore frontend-js-spa-web 5.0.5 artifact properties
- artifact:ignore frontend-taglib-form-navigator 5.0.2 change log
- artifact:ignore frontend-taglib-form-navigator 5.0.2 prep next
- artifact:ignore frontend-taglib-form-navigator 5.0.2 artifact properties
- artifact:ignore frontend-theme-classic 5.0.3 change log
- artifact:ignore frontend-theme-classic 5.0.3 prep next
- artifact:ignore frontend-theme-classic 5.0.3 artifact properties
- artifact:ignore hello-velocity-web 6.0.2 change log
- artifact:ignore hello-velocity-web 6.0.2 prep next
- artifact:ignore hello-velocity-web 6.0.2 artifact properties
- artifact:ignore invitation-invite-members-service 7.0.3 change log
- artifact:ignore invitation-invite-members-service 7.0.3 prep next
- artifact:ignore invitation-invite-members-service 7.0.3 artifact properties
- artifact:ignore journal-lang 6.0.7 change log
- artifact:ignore journal-lang 6.0.7 prep next
- artifact:ignore journal-lang 6.0.7 artifact properties
- artifact:ignore knowledge-base-service 5.0.2 change log
- artifact:ignore knowledge-base-service 5.0.2 prep next
- artifact:ignore knowledge-base-service 5.0.2 artifact properties
- artifact:ignore layout-service 2.0.2 change log
- artifact:ignore layout-service 2.0.2 prep next
- artifact:ignore layout-service 2.0.2 artifact properties
- artifact:ignore marketplace-service 7.0.2 change log
- artifact:ignore marketplace-service 7.0.2 prep next
- artifact:ignore marketplace-service 7.0.2 artifact properties
- artifact:ignore message-boards-layout-set-prototype 5.0.1 change log
- artifact:ignore message-boards-layout-set-prototype 5.0.1 prep next
- artifact:ignore message-boards-layout-set-prototype 5.0.1 artifact properties
- artifact:ignore mobile-device-rules-service 5.0.2 change log
- artifact:ignore mobile-device-rules-service 5.0.2 prep next
- artifact:ignore mobile-device-rules-service 5.0.2 artifact properties
- artifact:ignore oauth2-provider-rest 4.0.2 change log
- artifact:ignore oauth2-provider-rest 4.0.2 prep next
- artifact:ignore oauth2-provider-rest 4.0.2 artifact properties
- artifact:ignore oauth2-provider-scope-impl 4.0.2 change log
- artifact:ignore oauth2-provider-scope-impl 4.0.2 prep next
- artifact:ignore oauth2-provider-scope-impl 4.0.2 artifact properties
- artifact:ignore oauth2-provider-service 4.0.2 change log
- artifact:ignore oauth2-provider-service 4.0.2 prep next
- artifact:ignore oauth2-provider-service 4.0.2 artifact properties
- artifact:ignore petra-portlet-url-builder 1.0.3 change log
- artifact:ignore petra-portlet-url-builder 1.0.3 prep next
- artifact:ignore petra-portlet-url-builder 1.0.3 artifact properties
- artifact:ignore portal-async-advice 3.0.2 change log
- artifact:ignore portal-async-advice 3.0.2 prep next
- artifact:ignore portal-async-advice 3.0.2 artifact properties
- artifact:ignore portal-upload 4.0.2 change log
- artifact:ignore portal-upload 4.0.2 prep next
- artifact:ignore portal-upload 4.0.2 artifact properties
- artifact:ignore portal-background-task-service 7.0.3 change log
- artifact:ignore portal-background-task-service 7.0.3 prep next
- artifact:ignore portal-background-task-service 7.0.3 artifact properties
- artifact:ignore portal-cache-ehcache-impl 4.0.1 change log
- artifact:ignore portal-cache-ehcache-impl 4.0.1 prep next
- artifact:ignore portal-cache-ehcache-impl 4.0.1 artifact properties
- artifact:ignore portal-lock-service 6.0.2 change log
- artifact:ignore portal-lock-service 6.0.2 prep next
- artifact:ignore portal-lock-service 6.0.2 artifact properties
- artifact:ignore portal-remote-http-tunnel-extender 6.0.2 change log
- artifact:ignore portal-remote-http-tunnel-extender 6.0.2 prep next
- artifact:ignore portal-remote-http-tunnel-extender 6.0.2 artifact properties
- artifact:ignore portal-remote-soap-extender-impl 5.0.2 change log
- artifact:ignore portal-remote-soap-extender-impl 5.0.2 prep next
- artifact:ignore portal-remote-soap-extender-impl 5.0.2 artifact properties
- artifact:ignore portal-search-api 5.1.0 change log
- artifact:ignore portal-search-api 5.1.0 prep next
- artifact:ignore portal-search-api 5.1.0 artifact properties
- artifact:ignore portal-security-audit-storage-service 6.0.3 change log
- artifact:ignore portal-security-audit-storage-service 6.0.3 prep next
- artifact:ignore portal-security-audit-storage-service 6.0.3 artifact properties
- artifact:ignore portal-workflow-kaleo-runtime-api 6.1.0 change log
- artifact:ignore portal-workflow-kaleo-runtime-api 6.1.0 prep next
- artifact:ignore portal-workflow-kaleo-runtime-api 6.1.0 artifact properties
- artifact:ignore portlet-configuration-sharing-web 6.0.2 change log
- artifact:ignore portlet-configuration-sharing-web 6.0.2 prep next
- artifact:ignore portlet-configuration-sharing-web 6.0.2 artifact properties
- artifact:ignore push-notifications-service 5.0.2 change log
- artifact:ignore push-notifications-service 5.0.2 prep next
- artifact:ignore push-notifications-service 5.0.2 artifact properties
- artifact:ignore ratings-page-ratings-web 6.0.2 change log
- artifact:ignore ratings-page-ratings-web 6.0.2 prep next
- artifact:ignore ratings-page-ratings-web 6.0.2 artifact properties
- artifact:ignore reading-time-service 4.0.2 change log
- artifact:ignore reading-time-service 4.0.2 prep next
- artifact:ignore reading-time-service 4.0.2 artifact properties
- artifact:ignore site-service 4.0.2 change log
- artifact:ignore site-service 4.0.2 prep next
- artifact:ignore site-service 4.0.2 artifact properties
- artifact:ignore site-navigation-service 4.0.2 change log
- artifact:ignore site-navigation-service 4.0.2 prep next
- artifact:ignore site-navigation-service 4.0.2 artifact properties
- artifact:ignore subscription-service 4.0.2 change log
- artifact:ignore subscription-service 4.0.2 prep next
- artifact:ignore subscription-service 4.0.2 artifact properties
- artifact:ignore users-admin-api 6.0.3 change log
- artifact:ignore users-admin-api 6.0.3 prep next
- artifact:ignore users-admin-api 6.0.3 artifact properties
- artifact:ignore wiki-layout-prototype 5.0.2 change log
- artifact:ignore wiki-layout-prototype 5.0.2 prep next
- artifact:ignore wiki-layout-prototype 5.0.2 artifact properties
- artifact:ignore headless-discovery-impl 4.0.2 change log
- artifact:ignore headless-discovery-impl 4.0.2 prep next
- artifact:ignore headless-discovery-impl 4.0.2 artifact properties
- build.gradle auto SF
- artifact:ignore adaptive-media-document-library 5.0.1 change log
- artifact:ignore adaptive-media-document-library 5.0.1 prep next
- artifact:ignore adaptive-media-document-library 5.0.1 artifact properties
- artifact:ignore adaptive-media-document-library-thumbnails 5.0.2 change log
- artifact:ignore adaptive-media-document-library-thumbnails 5.0.2 prep next
- artifact:ignore adaptive-media-document-library-thumbnails 5.0.2 artifact properties
- artifact:ignore adaptive-media-image-impl 5.0.3 change log
- artifact:ignore adaptive-media-image-impl 5.0.3 prep next
- artifact:ignore adaptive-media-image-impl 5.0.3 artifact properties
- artifact:ignore adaptive-media-image-service 5.0.2 change log
- artifact:ignore adaptive-media-image-service 5.0.2 prep next
- artifact:ignore adaptive-media-image-service 5.0.2 artifact properties
- artifact:ignore asset-display-page-service 4.0.2 change log
- artifact:ignore asset-display-page-service 4.0.2 prep next
- artifact:ignore asset-display-page-service 4.0.2 artifact properties
- artifact:ignore blogs-service 5.0.2 change log
- artifact:ignore blogs-service 5.0.2 prep next
- artifact:ignore blogs-service 5.0.2 artifact properties
- artifact:ignore bookmarks-service 5.0.2 change log
- artifact:ignore bookmarks-service 5.0.2 prep next
- artifact:ignore bookmarks-service 5.0.2 artifact properties
- artifact:ignore calendar-service 6.0.5 change log
- artifact:ignore calendar-service 6.0.5 prep next
- artifact:ignore calendar-service 6.0.5 artifact properties
- artifact:ignore change-tracking-service 3.0.4 change log
- artifact:ignore change-tracking-service 3.0.4 prep next
- artifact:ignore change-tracking-service 3.0.4 artifact properties
- artifact:ignore commerce-service 11.0.5 change log
- artifact:ignore commerce-service 11.0.5 prep next
- artifact:ignore commerce-service 11.0.5 artifact properties
- artifact:ignore contacts-service 6.0.2 change log
- artifact:ignore contacts-service 6.0.2 prep next
- artifact:ignore contacts-service 6.0.2 artifact properties
- artifact:ignore dynamic-data-mapping-api 9.3.0 change log
- artifact:ignore dynamic-data-mapping-api 9.3.0 prep next
- artifact:ignore dynamic-data-mapping-api 9.3.0 artifact properties
- artifact:ignore frontend-taglib-clay 7.1.7 change log
- artifact:ignore frontend-taglib-clay 7.1.7 prep next
- artifact:ignore frontend-taglib-clay 7.1.7 artifact properties
- artifact:ignore journal-uad 3.0.2 change log
- artifact:ignore journal-uad 3.0.2 prep next
- artifact:ignore journal-uad 3.0.2 artifact properties
- artifact:ignore message-boards-service 5.0.3 change log
- artifact:ignore message-boards-service 5.0.3 prep next
- artifact:ignore message-boards-service 5.0.3 artifact properties
- artifact:ignore polls-service 7.0.2 change log
- artifact:ignore polls-service 7.0.2 prep next
- artifact:ignore polls-service 7.0.2 artifact properties
- artifact:ignore portal-search 8.0.3 change log
- artifact:ignore portal-search 8.0.3 prep next
- artifact:ignore portal-search 8.0.3 artifact properties
- artifact:ignore portal-search-elasticsearch7-impl 6.0.4 change log
- artifact:ignore portal-search-elasticsearch7-impl 6.0.4 prep next
- artifact:ignore portal-search-elasticsearch7-impl 6.0.4 artifact properties
- artifact:ignore portal-workflow-kaleo-runtime-impl 6.0.2 change log
- artifact:ignore portal-workflow-kaleo-runtime-impl 6.0.2 prep next
- artifact:ignore portal-workflow-kaleo-runtime-impl 6.0.2 artifact properties
- artifact:ignore portal-workflow-kaleo-service 6.0.2 change log
- artifact:ignore portal-workflow-kaleo-service 6.0.2 prep next
- artifact:ignore portal-workflow-kaleo-service 6.0.2 artifact properties
- artifact:ignore redirect-service 2.0.3 change log
- artifact:ignore redirect-service 2.0.3 prep next
- artifact:ignore redirect-service 2.0.3 artifact properties
- artifact:ignore segments-service 3.0.3 change log
- artifact:ignore segments-service 3.0.3 prep next
- artifact:ignore segments-service 3.0.3 artifact properties
- artifact:ignore trash-service 5.0.2 change log
- artifact:ignore trash-service 5.0.2 prep next
- artifact:ignore trash-service 5.0.2 artifact properties
- artifact:ignore users-admin-impl 5.0.4 change log
- artifact:ignore users-admin-impl 5.0.4 prep next
- artifact:ignore users-admin-impl 5.0.4 artifact properties
- artifact:ignore wiki-editor-configuration 5.0.2 change log
- artifact:ignore wiki-editor-configuration 5.0.2 prep next
- artifact:ignore wiki-editor-configuration 5.0.2 artifact properties
- artifact:ignore wiki-service 5.0.2 change log
- artifact:ignore wiki-service 5.0.2 prep next
- artifact:ignore wiki-service 5.0.2 artifact properties
- build.gradle auto SF
- LPS-130715 Asset Publisher isShowContextLink calculation is too CPU heavy
- LPS-130715 Removes unused method
- LPS-129700 Remove Liferay.Util.selectEntityHandler usage from segments
- LPS-129897 Create new  item selector criteria based in the role type to allow select more than one type per selector window (and deprecate the old criterion one)
- LPS-129897 Create the criterion handlers (and deprecate the old one)
- LPS-129897 Create the role selector views (and deprecate the old one)
- LPS-129897 Semver
- LPS-129897 Index user role ids
- LPS-129897 Adapt logic to Item selector
- LPS-129897 Rename
- LPS-129897 Adapt the current view to the new criteria and allow multiple select (and keep backwards compatibility)
- LPS-129897 Create a new Segments property and FieldCustomizer based in the current one to select site and organization roles
- LPS-129897 Add lang property
- LPS-129897 build lang
- LPS-129897 Like this
- artifact:ignore asset-list-service 3.0.5 change log
- artifact:ignore asset-list-service 3.0.5 prep next
- artifact:ignore asset-list-service 3.0.5 artifact properties
- artifact:ignore asset-service 5.0.4 change log
- artifact:ignore asset-service 5.0.4 prep next
- artifact:ignore asset-service 5.0.4 artifact properties
- artifact:ignore commerce-taglib 5.0.2 change log
- artifact:ignore commerce-taglib 5.0.2 prep next
- artifact:ignore commerce-taglib 5.0.2 artifact properties
- artifact:ignore data-engine-service 3.0.3 change log
- artifact:ignore data-engine-service 3.0.3 prep next
- artifact:ignore data-engine-service 3.0.3 artifact properties
- artifact:ignore document-library-service 6.0.4 change log
- artifact:ignore document-library-service 6.0.4 prep next
- artifact:ignore document-library-service 6.0.4 artifact properties
- artifact:ignore dynamic-data-lists-service 5.0.3 change log
- artifact:ignore dynamic-data-lists-service 5.0.3 prep next
- artifact:ignore dynamic-data-lists-service 5.0.3 artifact properties
- artifact:ignore dynamic-data-mapping-service 6.0.5 change log
- artifact:ignore dynamic-data-mapping-service 6.0.5 prep next
- artifact:ignore dynamic-data-mapping-service 6.0.5 artifact properties
- artifact:ignore export-import-service 8.0.3 change log
- artifact:ignore export-import-service 8.0.3 prep next
- artifact:ignore export-import-service 8.0.3 artifact properties
- artifact:ignore fragment-service 4.0.3 change log
- artifact:ignore fragment-service 4.0.3 prep next
- artifact:ignore fragment-service 4.0.3 artifact properties
- artifact:ignore frontend-taglib 6.0.2 change log
- artifact:ignore frontend-taglib 6.0.2 prep next
- artifact:ignore frontend-taglib 6.0.2 artifact properties
- artifact:ignore info-taglib 2.0.3 change log
- artifact:ignore info-taglib 2.0.3 prep next
- artifact:ignore info-taglib 2.0.3 artifact properties
- artifact:ignore journal-service 7.0.3 change log
- artifact:ignore journal-service 7.0.3 prep next
- artifact:ignore journal-service 7.0.3 artifact properties
- artifact:ignore layout-page-template-service 4.0.3 change log
- artifact:ignore layout-page-template-service 4.0.3 prep next
- artifact:ignore layout-page-template-service 4.0.3 artifact properties
- artifact:ignore layout-seo-service 3.0.3 change log
- artifact:ignore layout-seo-service 3.0.3 prep next
- artifact:ignore layout-seo-service 3.0.3 artifact properties
- artifact:ignore layout-taglib 6.0.5 change log
- artifact:ignore layout-taglib 6.0.5 prep next
- artifact:ignore layout-taglib 6.0.5 artifact properties
- artifact:ignore license-manager-web 6.0.1 change log
- artifact:ignore license-manager-web 6.0.1 prep next
- artifact:ignore license-manager-web 6.0.1 artifact properties
- artifact:ignore product-navigation-taglib 6.0.3 change log
- artifact:ignore product-navigation-taglib 6.0.3 prep next
- artifact:ignore product-navigation-taglib 6.0.3 artifact properties
- artifact:ignore roles-item-selector-api 4.0.1 change log
- artifact:ignore roles-item-selector-api 4.0.1 prep next
- artifact:ignore roles-item-selector-api 4.0.1 artifact properties
- artifact:ignore segments-lang 3.0.2 change log
- artifact:ignore segments-lang 3.0.2 prep next
- artifact:ignore segments-lang 3.0.2 artifact properties
- artifact:ignore segments-service 3.0.4 change log
- artifact:ignore segments-service 3.0.4 prep next
- artifact:ignore segments-service 3.0.4 artifact properties
- artifact:ignore sharing-taglib 3.0.3 change log
- artifact:ignore sharing-taglib 3.0.3 prep next
- artifact:ignore sharing-taglib 3.0.3 artifact properties
- artifact:ignore site-navigation-taglib 6.0.2 change log
- artifact:ignore site-navigation-taglib 6.0.2 prep next
- artifact:ignore site-navigation-taglib 6.0.2 artifact properties
- artifact:ignore translation-service 2.0.3 change log
- artifact:ignore translation-service 2.0.3 prep next
- artifact:ignore translation-service 2.0.3 artifact properties
- artifact:ignore users-admin-impl 5.0.5 change log
- artifact:ignore users-admin-impl 5.0.5 prep next
- artifact:ignore users-admin-impl 5.0.5 artifact properties
- build.gradle auto SF
- LPS-77699 Update Translations
- artifact:ignore analytics-settings-web 5.0.4 change log
- artifact:ignore analytics-settings-web 5.0.4 prep next
- artifact:ignore analytics-settings-web 5.0.4 artifact properties
- artifact:ignore announcements-web 6.0.2 change log
- artifact:ignore announcements-web 6.0.2 prep next
- artifact:ignore announcements-web 6.0.2 artifact properties
- artifact:ignore amazon-rankings-web 5.0.3 change log
- artifact:ignore amazon-rankings-web 5.0.3 prep next
- artifact:ignore amazon-rankings-web 5.0.3 artifact properties
- artifact:ignore currency-converter-web 5.0.3 change log
- artifact:ignore currency-converter-web 5.0.3 prep next
- artifact:ignore currency-converter-web 5.0.3 artifact properties
- artifact:ignore dictionary-web 5.0.1 change log
- artifact:ignore dictionary-web 5.0.1 prep next
- artifact:ignore dictionary-web 5.0.1 artifact properties
- artifact:ignore directory-web 5.0.2 change log
- artifact:ignore directory-web 5.0.2 prep next
- artifact:ignore directory-web 5.0.2 artifact properties
- artifact:ignore google-maps-web 5.0.2 change log
- artifact:ignore google-maps-web 5.0.2 prep next
- artifact:ignore google-maps-web 5.0.2 artifact properties
- artifact:ignore journal-content-search-web 5.0.1 change log
- artifact:ignore journal-content-search-web 5.0.1 prep next
- artifact:ignore journal-content-search-web 5.0.1 artifact properties
- artifact:ignore loan-calculator-web 5.0.1 change log
- artifact:ignore loan-calculator-web 5.0.1 prep next
- artifact:ignore loan-calculator-web 5.0.1 artifact properties
- artifact:ignore mail-reader-web 5.0.3 change log
- artifact:ignore mail-reader-web 5.0.3 prep next
- artifact:ignore mail-reader-web 5.0.3 artifact properties
- artifact:ignore network-utilities-web 5.0.2 change log
- artifact:ignore network-utilities-web 5.0.2 prep next
- artifact:ignore network-utilities-web 5.0.2 artifact properties
- artifact:ignore oauth-web 5.0.3 change log
- artifact:ignore oauth-web 5.0.3 prep next
- artifact:ignore oauth-web 5.0.3 artifact properties
- artifact:ignore password-generator-web 5.0.1 change log
- artifact:ignore password-generator-web 5.0.1 prep next
- artifact:ignore password-generator-web 5.0.1 artifact properties
- artifact:ignore portal-security-wedeploy-auth-web 5.0.2 change log
- artifact:ignore portal-security-wedeploy-auth-web 5.0.2 prep next
- artifact:ignore portal-security-wedeploy-auth-web 5.0.2 artifact properties
- artifact:ignore quick-note-web 6.0.1 change log
- artifact:ignore quick-note-web 6.0.1 prep next
- artifact:ignore quick-note-web 6.0.1 artifact properties
- artifact:ignore social-activity-web 6.0.3 change log
- artifact:ignore social-activity-web 6.0.3 prep next
- artifact:ignore social-activity-web 6.0.3 artifact properties
- artifact:ignore social-group-statistics-web 6.0.2 change log
- artifact:ignore social-group-statistics-web 6.0.2 prep next
- artifact:ignore social-group-statistics-web 6.0.2 artifact properties
- artifact:ignore social-requests-web 5.0.1 change log
- artifact:ignore social-requests-web 5.0.1 prep next
- artifact:ignore social-requests-web 5.0.1 artifact properties
- artifact:ignore social-user-statistics-web 7.0.2 change log
- artifact:ignore social-user-statistics-web 7.0.2 prep next
- artifact:ignore social-user-statistics-web 7.0.2 artifact properties
- artifact:ignore sync-web 5.0.2 change log
- artifact:ignore sync-web 5.0.2 prep next
- artifact:ignore sync-web 5.0.2 artifact properties
- artifact:ignore translator-web 5.0.3 change log
- artifact:ignore translator-web 5.0.3 prep next
- artifact:ignore translator-web 5.0.3 artifact properties
- artifact:ignore unit-converter-web 5.0.1 change log
- artifact:ignore unit-converter-web 5.0.1 prep next
- artifact:ignore unit-converter-web 5.0.1 artifact properties
- artifact:ignore weather-web 5.0.3 change log
- artifact:ignore weather-web 5.0.3 prep next
- artifact:ignore weather-web 5.0.3 artifact properties
- artifact:ignore web-proxy-web 5.0.1 change log
- artifact:ignore web-proxy-web 5.0.1 prep next
- artifact:ignore web-proxy-web 5.0.1 artifact properties
- artifact:ignore xsl-content-web 6.0.2 change log
- artifact:ignore xsl-content-web 6.0.2 prep next
- artifact:ignore xsl-content-web 6.0.2 artifact properties
- artifact:ignore youtube-web 5.0.2 change log
- artifact:ignore youtube-web 5.0.2 prep next
- artifact:ignore youtube-web 5.0.2 artifact properties
- artifact:ignore asset-browser-web 5.0.2 change log
- artifact:ignore asset-browser-web 5.0.2 prep next
- artifact:ignore asset-browser-web 5.0.2 artifact properties
- artifact:ignore asset-taglib 6.0.5 change log
- artifact:ignore asset-taglib 6.0.5 prep next
- artifact:ignore asset-taglib 6.0.5 artifact properties
- artifact:ignore blogs-recent-bloggers-web 6.0.2 change log
- artifact:ignore blogs-recent-bloggers-web 6.0.2 prep next
- artifact:ignore blogs-recent-bloggers-web 6.0.2 artifact properties
- artifact:ignore change-tracking-web 2.0.4 change log
- artifact:ignore change-tracking-web 2.0.4 prep next
- artifact:ignore change-tracking-web 2.0.4 artifact properties
- artifact:ignore comment-page-comments-web 5.0.1 change log
- artifact:ignore comment-page-comments-web 5.0.1 prep next
- artifact:ignore comment-page-comments-web 5.0.1 artifact properties
- artifact:ignore commerce-address-web 4.0.2 change log
- artifact:ignore commerce-address-web 4.0.2 prep next
- artifact:ignore commerce-address-web 4.0.2 artifact properties
- artifact:ignore commerce-availability-estimate-web 4.0.1 change log
- artifact:ignore commerce-availability-estimate-web 4.0.1 prep next
- artifact:ignore commerce-availability-estimate-web 4.0.1 artifact properties
- artifact:ignore commerce-cart-taglib 5.0.2 change log
- artifact:ignore commerce-cart-taglib 5.0.2 prep next
- artifact:ignore commerce-cart-taglib 5.0.2 artifact properties
- artifact:ignore commerce-currency-web 4.0.1 change log
- artifact:ignore commerce-currency-web 4.0.1 prep next
- artifact:ignore commerce-currency-web 4.0.1 artifact properties
- artifact:ignore commerce-frontend-taglib 12.0.1 change log
- artifact:ignore commerce-frontend-taglib 12.0.1 prep next
- artifact:ignore commerce-frontend-taglib 12.0.1 artifact properties
- artifact:ignore commerce-product-measurement-unit-web 4.0.1 change log
- artifact:ignore commerce-product-measurement-unit-web 4.0.1 prep next
- artifact:ignore commerce-product-measurement-unit-web 4.0.1 artifact properties
- artifact:ignore commerce-shipment-content-web 4.0.1 change log
- artifact:ignore commerce-shipment-content-web 4.0.1 prep next
- artifact:ignore commerce-shipment-content-web 4.0.1 artifact properties
- artifact:ignore content-dashboard-web 2.0.4 change log
- artifact:ignore content-dashboard-web 2.0.4 prep next
- artifact:ignore content-dashboard-web 2.0.4 artifact properties
- artifact:ignore dispatch-web 3.0.3 change log
- artifact:ignore dispatch-web 3.0.3 prep next
- artifact:ignore dispatch-web 3.0.3 artifact properties
- artifact:ignore dynamic-data-mapping-web 5.0.2 change log
- artifact:ignore dynamic-data-mapping-web 5.0.2 prep next
- artifact:ignore dynamic-data-mapping-web 5.0.2 artifact properties
- artifact:ignore expando-web 5.0.2 change log
- artifact:ignore expando-web 5.0.2 prep next
- artifact:ignore expando-web 5.0.2 artifact properties
- artifact:ignore export-import-changeset-taglib 4.0.2 change log
- artifact:ignore export-import-changeset-taglib 4.0.2 prep next
- artifact:ignore export-import-changeset-taglib 4.0.2 artifact properties
- artifact:ignore export-import-web 5.0.2 change log
- artifact:ignore export-import-web 5.0.2 prep next
- artifact:ignore export-import-web 5.0.2 artifact properties
- artifact:ignore flags-web 6.0.2 change log
- artifact:ignore flags-web 6.0.2 prep next
- artifact:ignore flags-web 6.0.2 artifact properties
- artifact:ignore fragment-renderer-menu-display-impl 2.0.2 change log
- artifact:ignore fragment-renderer-menu-display-impl 2.0.2 prep next
- artifact:ignore fragment-renderer-menu-display-impl 2.0.2 artifact properties
- artifact:ignore fragment-web 4.0.2 change log
- artifact:ignore fragment-web 4.0.2 prep next
- artifact:ignore fragment-web 4.0.2 artifact properties
- artifact:ignore iframe-web 5.0.2 change log
- artifact:ignore iframe-web 5.0.2 prep next
- artifact:ignore iframe-web 5.0.2 artifact properties
- artifact:ignore image-uploader-web 5.0.1 change log
- artifact:ignore image-uploader-web 5.0.1 prep next
- artifact:ignore image-uploader-web 5.0.1 artifact properties
- artifact:ignore item-selector-taglib 5.0.3 change log
- artifact:ignore item-selector-taglib 5.0.3 prep next
- artifact:ignore item-selector-taglib 5.0.3 artifact properties
- artifact:ignore layout-content-page-editor-web 3.0.11 change log
- artifact:ignore layout-content-page-editor-web 3.0.11 prep next
- artifact:ignore layout-content-page-editor-web 3.0.11 artifact properties
- artifact:ignore layout-page-template-admin-web 2.0.3 change log
- artifact:ignore layout-page-template-admin-web 2.0.3 prep next
- artifact:ignore layout-page-template-admin-web 2.0.3 artifact properties
- artifact:ignore login-web 6.0.2 change log
- artifact:ignore login-web 6.0.2 prep next
- artifact:ignore login-web 6.0.2 artifact properties
- artifact:ignore marketplace-app-manager-web 5.0.3 change log
- artifact:ignore marketplace-app-manager-web 5.0.3 prep next
- artifact:ignore marketplace-app-manager-web 5.0.3 artifact properties
- artifact:ignore microblogs-web 6.0.2 change log
- artifact:ignore microblogs-web 6.0.2 prep next
- artifact:ignore microblogs-web 6.0.2 artifact properties
- artifact:ignore mobile-device-rules-web 5.0.1 change log
- artifact:ignore mobile-device-rules-web 5.0.1 prep next
- artifact:ignore mobile-device-rules-web 5.0.1 artifact properties
- artifact:ignore monitoring-web 5.0.1 change log
- artifact:ignore monitoring-web 5.0.1 prep next
- artifact:ignore monitoring-web 5.0.1 artifact properties
- artifact:ignore my-subscriptions-web 5.0.3 change log
- artifact:ignore my-subscriptions-web 5.0.3 prep next
- artifact:ignore my-subscriptions-web 5.0.3 artifact properties
- artifact:ignore nested-portlets-web 6.0.3 change log
- artifact:ignore nested-portlets-web 6.0.3 prep next
- artifact:ignore nested-portlets-web 6.0.3 artifact properties
- artifact:ignore password-policies-admin-web 5.0.2 change log
- artifact:ignore password-policies-admin-web 5.0.2 prep next
- artifact:ignore password-policies-admin-web 5.0.2 artifact properties
- artifact:ignore plugins-admin-web 5.0.2 change log
- artifact:ignore plugins-admin-web 5.0.2 prep next
- artifact:ignore plugins-admin-web 5.0.2 artifact properties
- artifact:ignore polls-web 6.0.2 change log
- artifact:ignore polls-web 6.0.2 prep next
- artifact:ignore polls-web 6.0.2 artifact properties
- artifact:ignore portal-instances-web 5.0.4 change log
- artifact:ignore portal-instances-web 5.0.4 prep next
- artifact:ignore portal-instances-web 5.0.4 artifact properties
- artifact:ignore portal-search-admin-web 4.0.2 change log
- artifact:ignore portal-search-admin-web 4.0.2 prep next
- artifact:ignore portal-search-admin-web 4.0.2 artifact properties
- artifact:ignore portal-security-service-access-policy-web 5.0.2 change log
- artifact:ignore portal-security-service-access-policy-web 5.0.2 prep next
- artifact:ignore portal-security-service-access-policy-web 5.0.2 artifact properties
- artifact:ignore portal-settings-authentication-ldap-web 5.0.2 change log
- artifact:ignore portal-settings-authentication-ldap-web 5.0.2 prep next
- artifact:ignore portal-settings-authentication-ldap-web 5.0.2 artifact properties
- artifact:ignore portlet-configuration-css-web 6.0.3 change log
- artifact:ignore portlet-configuration-css-web 6.0.3 prep next
- artifact:ignore portlet-configuration-css-web 6.0.3 artifact properties
- artifact:ignore portlet-configuration-web 5.0.2 change log
- artifact:ignore portlet-configuration-web 5.0.2 prep next
- artifact:ignore portlet-configuration-web 5.0.2 artifact properties
- artifact:ignore push-notifications-web 5.0.2 change log
- artifact:ignore push-notifications-web 5.0.2 prep next
- artifact:ignore push-notifications-web 5.0.2 artifact properties
- artifact:ignore roles-admin-web 5.0.5 change log
- artifact:ignore roles-admin-web 5.0.5 prep next
- artifact:ignore roles-admin-web 5.0.5 artifact properties
- artifact:ignore rss-web 7.0.3 change log
- artifact:ignore rss-web 7.0.3 prep next
- artifact:ignore rss-web 7.0.3 artifact properties
- artifact:ignore segments-web 3.0.3 change log
- artifact:ignore segments-web 3.0.3 prep next
- artifact:ignore segments-web 3.0.3 artifact properties
- artifact:ignore server-admin-web 5.0.5 change log
- artifact:ignore server-admin-web 5.0.5 prep next
- artifact:ignore server-admin-web 5.0.5 artifact properties
- artifact:ignore site-browser-web 6.0.3 change log
- artifact:ignore site-browser-web 6.0.3 prep next
- artifact:ignore site-browser-web 6.0.3 artifact properties
- artifact:ignore site-memberships-web 5.0.5 change log
- artifact:ignore site-memberships-web 5.0.5 prep next
- artifact:ignore site-memberships-web 5.0.5 artifact properties
- artifact:ignore site-teams-web 5.0.2 change log
- artifact:ignore site-teams-web 5.0.2 prep next
- artifact:ignore site-teams-web 5.0.2 artifact properties
- artifact:ignore site-navigation-breadcrumb-web 7.0.1 change log
- artifact:ignore site-navigation-breadcrumb-web 7.0.1 prep next
- artifact:ignore site-navigation-breadcrumb-web 7.0.1 artifact properties
- artifact:ignore site-navigation-language-web 7.0.1 change log
- artifact:ignore site-navigation-language-web 7.0.1 prep next
- artifact:ignore site-navigation-language-web 7.0.1 artifact properties
- artifact:ignore site-navigation-menu-web 6.0.1 change log
- artifact:ignore site-navigation-menu-web 6.0.1 prep next
- artifact:ignore site-navigation-menu-web 6.0.1 artifact properties
- artifact:ignore site-navigation-site-map-web 6.0.1 change log
- artifact:ignore site-navigation-site-map-web 6.0.1 prep next
- artifact:ignore site-navigation-site-map-web 6.0.1 artifact properties
- artifact:ignore staging-bar-web 5.0.2 change log
- artifact:ignore staging-bar-web 5.0.2 prep next
- artifact:ignore staging-bar-web 5.0.2 artifact properties
- artifact:ignore staging-processes-web 5.0.1 change log
- artifact:ignore staging-processes-web 5.0.1 prep next
- artifact:ignore staging-processes-web 5.0.1 artifact properties
- artifact:ignore style-book-web 2.0.2 change log
- artifact:ignore style-book-web 2.0.2 prep next
- artifact:ignore style-book-web 2.0.2 artifact properties
- artifact:ignore translation-web 2.0.2 change log
- artifact:ignore translation-web 2.0.2 prep next
- artifact:ignore translation-web 2.0.2 artifact properties
- artifact:ignore user-associated-data-web 6.0.3 change log
- artifact:ignore user-associated-data-web 6.0.3 prep next
- artifact:ignore user-associated-data-web 6.0.3 artifact properties
- artifact:ignore user-groups-admin-web 5.0.2 change log
- artifact:ignore user-groups-admin-web 5.0.2 prep next
- artifact:ignore user-groups-admin-web 5.0.2 artifact properties
- artifact:ignore wiki-navigation-web 6.0.1 change log
- artifact:ignore wiki-navigation-web 6.0.1 prep next
- artifact:ignore wiki-navigation-web 6.0.1 artifact properties
- artifact:ignore journal-content-asset-addon-entry-comments 5.0.1 change log
- artifact:ignore journal-content-asset-addon-entry-comments 5.0.1 prep next
- artifact:ignore journal-content-asset-addon-entry-comments 5.0.1 artifact properties
- artifact:ignore layout-type-controller-display-page 3.0.2 change log
- artifact:ignore layout-type-controller-display-page 3.0.2 prep next
- artifact:ignore layout-type-controller-display-page 3.0.2 artifact properties
- build.gradle auto SF
- artifact:ignore asset-categories-admin-web 5.0.3 change log
- artifact:ignore asset-categories-admin-web 5.0.3 prep next
- artifact:ignore asset-categories-admin-web 5.0.3 artifact properties
- artifact:ignore asset-categories-item-selector-web 1.0.3 change log
- artifact:ignore asset-categories-item-selector-web 1.0.3 prep next
- artifact:ignore asset-categories-item-selector-web 1.0.3 artifact properties
- artifact:ignore asset-categories-navigation-web 6.0.2 change log
- artifact:ignore asset-categories-navigation-web 6.0.2 prep next
- artifact:ignore asset-categories-navigation-web 6.0.2 artifact properties
- artifact:ignore asset-list-web 3.0.4 change log
- artifact:ignore asset-list-web 3.0.4 prep next
- artifact:ignore asset-list-web 3.0.4 artifact properties
- artifact:ignore asset-publisher-web 5.0.7 change log
- artifact:ignore asset-publisher-web 5.0.7 prep next
- artifact:ignore asset-publisher-web 5.0.7 artifact properties
- artifact:ignore asset-tags-navigation-web 7.0.3 change log
- artifact:ignore asset-tags-navigation-web 7.0.3 prep next
- artifact:ignore asset-tags-navigation-web 7.0.3 artifact properties
- artifact:ignore blogs-web 6.0.2 change log
- artifact:ignore blogs-web 6.0.2 prep next
- artifact:ignore blogs-web 6.0.2 artifact properties
- artifact:ignore bookmarks-web 5.0.3 change log
- artifact:ignore bookmarks-web 5.0.3 prep next
- artifact:ignore bookmarks-web 5.0.3 artifact properties
- artifact:ignore calendar-web 5.0.2 change log
- artifact:ignore calendar-web 5.0.2 prep next
- artifact:ignore calendar-web 5.0.2 artifact properties
- artifact:ignore commerce-lang 4.0.6 change log
- artifact:ignore commerce-lang 4.0.6 prep next
- artifact:ignore commerce-lang 4.0.6 artifact properties
- artifact:ignore commerce-product-definitions-web 7.0.4 change log
- artifact:ignore commerce-product-definitions-web 7.0.4 prep next
- artifact:ignore commerce-product-definitions-web 7.0.4 artifact properties
- artifact:ignore commerce-product-options-web 4.0.2 change log
- artifact:ignore commerce-product-options-web 4.0.2 prep next
- artifact:ignore commerce-product-options-web 4.0.2 artifact properties
- artifact:ignore contacts-web 5.0.3 change log
- artifact:ignore contacts-web 5.0.3 prep next
- artifact:ignore contacts-web 5.0.3 artifact properties
- artifact:ignore document-library-web 6.0.6 change log
- artifact:ignore document-library-web 6.0.6 prep next
- artifact:ignore document-library-web 6.0.6 artifact properties
- artifact:ignore dynamic-data-lists-web 6.0.2 change log
- artifact:ignore dynamic-data-lists-web 6.0.2 prep next
- artifact:ignore dynamic-data-lists-web 6.0.2 artifact properties
- artifact:ignore dynamic-data-mapping-form-web 4.0.8 change log
- artifact:ignore dynamic-data-mapping-form-web 4.0.8 prep next
- artifact:ignore dynamic-data-mapping-form-web 4.0.8 artifact properties
- artifact:ignore item-selector-web 7.0.3 change log
- artifact:ignore item-selector-web 7.0.3 prep next
- artifact:ignore item-selector-web 7.0.3 artifact properties
- artifact:ignore journal-web 5.0.4 change log
- artifact:ignore journal-web 5.0.4 prep next
- artifact:ignore journal-web 5.0.4 artifact properties
- artifact:ignore knowledge-base-web 5.0.4 change log
- artifact:ignore knowledge-base-web 5.0.4 prep next
- artifact:ignore knowledge-base-web 5.0.4 artifact properties
- artifact:ignore layout-admin-web 5.0.6 change log
- artifact:ignore layout-admin-web 5.0.6 prep next
- artifact:ignore layout-admin-web 5.0.6 artifact properties
- artifact:ignore message-boards-web 5.0.6 change log
- artifact:ignore message-boards-web 5.0.6 prep next
- artifact:ignore message-boards-web 5.0.6 artifact properties
- artifact:ignore portal-search-web 6.0.4 change log
- artifact:ignore portal-search-web 6.0.4 prep next
- artifact:ignore portal-search-web 6.0.4 artifact properties
- artifact:ignore portal-workflow-web 4.0.2 change log
- artifact:ignore portal-workflow-web 4.0.2 prep next
- artifact:ignore portal-workflow-web 4.0.2 artifact properties
- artifact:ignore product-navigation-control-menu-web 6.0.2 change log
- artifact:ignore product-navigation-control-menu-web 6.0.2 prep next
- artifact:ignore product-navigation-control-menu-web 6.0.2 artifact properties
- artifact:ignore questions-web 2.0.5 change log
- artifact:ignore questions-web 2.0.5 prep next
- artifact:ignore questions-web 2.0.5 artifact properties
- artifact:ignore roles-item-selector-web 4.0.1 change log
- artifact:ignore roles-item-selector-web 4.0.1 prep next
- artifact:ignore roles-item-selector-web 4.0.1 artifact properties
- artifact:ignore segments-lang 3.0.3 change log
- artifact:ignore segments-lang 3.0.3 prep next
- artifact:ignore segments-lang 3.0.3 artifact properties
- artifact:ignore site-admin-web 5.0.6 change log
- artifact:ignore site-admin-web 5.0.6 prep next
- artifact:ignore site-admin-web 5.0.6 artifact properties
- artifact:ignore site-item-selector-web 6.0.2 change log
- artifact:ignore site-item-selector-web 6.0.2 prep next
- artifact:ignore site-item-selector-web 6.0.2 artifact properties
- artifact:ignore site-my-sites-web 6.0.2 change log
- artifact:ignore site-my-sites-web 6.0.2 prep next
- artifact:ignore site-my-sites-web 6.0.2 artifact properties
- artifact:ignore site-navigation-directory-web 6.0.2 change log
- artifact:ignore site-navigation-directory-web 6.0.2 prep next
- artifact:ignore site-navigation-directory-web 6.0.2 artifact properties
- artifact:ignore trash-web 5.0.3 change log
- artifact:ignore trash-web 5.0.3 prep next
- artifact:ignore trash-web 5.0.3 artifact properties
- artifact:ignore users-admin-web 6.0.5 change log
- artifact:ignore users-admin-web 6.0.5 prep next
- artifact:ignore users-admin-web 6.0.5 artifact properties
- artifact:ignore wiki-web 7.0.4 change log
- artifact:ignore wiki-web 7.0.4 prep next
- artifact:ignore wiki-web 7.0.4 artifact properties
- build.gradle auto SF
- artifact:ignore commerce-product-tax-category-web 4.0.1 change log
- artifact:ignore commerce-product-tax-category-web 4.0.1 prep next
- artifact:ignore commerce-product-tax-category-web 4.0.1 artifact properties
- artifact:ignore commerce-product-type-grouped-web 4.0.2 change log
- artifact:ignore commerce-product-type-grouped-web 4.0.2 prep next
- artifact:ignore commerce-product-type-grouped-web 4.0.2 artifact properties
- artifact:ignore commerce-warehouse-web 4.0.1 change log
- artifact:ignore commerce-warehouse-web 4.0.1 prep next
- artifact:ignore commerce-warehouse-web 4.0.1 artifact properties
- artifact:ignore journal-content-web 6.0.2 change log
- artifact:ignore journal-content-web 6.0.2 prep next
- artifact:ignore journal-content-web 6.0.2 artifact properties
- build.gradle auto SF
- artifact:ignore commerce-application-admin-web 5.0.2 change log
- artifact:ignore commerce-application-admin-web 5.0.2 prep next
- artifact:ignore commerce-application-admin-web 5.0.2 artifact properties
- artifact:ignore commerce-bom-admin-web 5.0.2 change log
- artifact:ignore commerce-bom-admin-web 5.0.2 prep next
- artifact:ignore commerce-bom-admin-web 5.0.2 artifact properties
- artifact:ignore commerce-machine-learning-forecast-alert-lang 4.0.2 change log
- artifact:ignore commerce-machine-learning-forecast-alert-lang 4.0.2 prep next
- artifact:ignore commerce-machine-learning-forecast-alert-lang 4.0.2 artifact properties
- artifact:ignore commerce-machine-learning-impl 5.0.3 change log
- artifact:ignore commerce-machine-learning-impl 5.0.3 prep next
- artifact:ignore commerce-machine-learning-impl 5.0.3 artifact properties
- artifact:ignore commerce-organization-web 5.0.4 change log
- artifact:ignore commerce-organization-web 5.0.4 prep next
- artifact:ignore commerce-organization-web 5.0.4 artifact properties
- artifact:ignore commerce-punchout-lang 4.0.2 change log
- artifact:ignore commerce-punchout-lang 4.0.2 prep next
- artifact:ignore commerce-punchout-lang 4.0.2 artifact properties
- artifact:ignore commerce-punchout-oauth2-provider-rest 4.0.2 change log
- artifact:ignore commerce-punchout-oauth2-provider-rest 4.0.2 prep next
- artifact:ignore commerce-punchout-oauth2-provider-rest 4.0.2 artifact properties
- artifact:ignore portal-reports-engine-console-service 8.0.2 change log
- artifact:ignore portal-reports-engine-console-service 8.0.2 prep next
- artifact:ignore portal-reports-engine-console-service 8.0.2 artifact properties
- artifact:ignore portal-search-elasticsearch-monitoring-web 2.0.2 change log
- artifact:ignore portal-search-elasticsearch-monitoring-web 2.0.2 prep next
- artifact:ignore portal-search-elasticsearch-monitoring-web 2.0.2 artifact properties
- artifact:ignore portal-search-tuning-rankings-web 3.0.2 change log
- artifact:ignore portal-search-tuning-rankings-web 3.0.2 prep next
- artifact:ignore portal-search-tuning-rankings-web 3.0.2 artifact properties
- artifact:ignore portal-workflow-kaleo-designer-web 5.0.2 change log
- artifact:ignore portal-workflow-kaleo-designer-web 5.0.2 prep next
- artifact:ignore portal-workflow-kaleo-designer-web 5.0.2 artifact properties
- artifact:ignore portal-workflow-kaleo-forms-service 5.0.2 change log
- artifact:ignore portal-workflow-kaleo-forms-service 5.0.2 prep next
- artifact:ignore portal-workflow-kaleo-forms-service 5.0.2 artifact properties
- artifact:ignore portal-workflow-metrics-lang 3.0.2 change log
- artifact:ignore portal-workflow-metrics-lang 3.0.2 prep next
- artifact:ignore portal-workflow-metrics-lang 3.0.2 artifact properties
- artifact:ignore portal-workflow-metrics-web 3.0.3 change log
- artifact:ignore portal-workflow-metrics-web 3.0.3 prep next
- artifact:ignore portal-workflow-metrics-web 3.0.3 artifact properties
- artifact:ignore saml-lang 1.0.4 change log
- artifact:ignore saml-lang 1.0.4 prep next
- artifact:ignore saml-lang 1.0.4 artifact properties
- artifact:ignore saml-web 5.0.4 change log
- artifact:ignore saml-web 5.0.4 prep next
- artifact:ignore saml-web 5.0.4 artifact properties
- artifact:ignore sharepoint-rest-oauth2-service 5.0.2 change log
- artifact:ignore sharepoint-rest-oauth2-service 5.0.2 prep next
- artifact:ignore sharepoint-rest-oauth2-service 5.0.2 artifact properties
- artifact:ignore sharepoint-rest-repository 5.0.2 change log
- artifact:ignore sharepoint-rest-repository 5.0.2 prep next
- artifact:ignore sharepoint-rest-repository 5.0.2 artifact properties
- build.gradle auto SF
- artifact:ignore portal-reports-engine-console-web 5.0.3 change log
- artifact:ignore portal-reports-engine-console-web 5.0.3 prep next
- artifact:ignore portal-reports-engine-console-web 5.0.3 artifact properties
- artifact:ignore portal-workflow-kaleo-forms-web 5.0.1 change log
- artifact:ignore portal-workflow-kaleo-forms-web 5.0.1 prep next
- artifact:ignore portal-workflow-kaleo-forms-web 5.0.1 artifact properties
- build.gradle auto SF
- artifact:ignore portal-vulcan-api 8.0.1 prep next
- artifact:ignore portal-vulcan-api 8.0.1 artifact properties
- artifact:ignore portal-vulcan-impl 5.0.4 prep next
- artifact:ignore portal-vulcan-impl 5.0.4 artifact properties
- LPS-130227 portal-search-web: don't rely on httpServletRequest URL
- artifact:ignore portal-search-web 6.0.5 change log
- artifact:ignore portal-search-web 6.0.5 prep next
- artifact:ignore portal-search-web 6.0.5 artifact properties
- LRQA-66676 Optimize macro
- LRQA-66676 Remove duplicate pause
- artifact:ignore portal-web 5.0.28 prep next
- artifact:ignore portal-web 5.0.28 releng
- 7.4.0 GA1 Release Apps: account, adaptive-media, address, alloy, analytics, announcements, app-builder, application-list, asset, batch-engine, bean-portlet, blogs, bulk, calendar, captcha, change-tracking, changeset, comment, commerce, configuration-admin, connected-app, contacts, content-dashboard, data-cleanup, data-engine, depot, dispatch, document-library-opener, document-library, dynamic-data-lists, dynamic-data-mapping, expando, export-import, external-reference, flags, fragment, friendly-url, frontend-css, frontend-editor, frontend-js, frontend-taglib, frontend-theme, frontend-token, gogo-shell, headless, iframe, image-uploader, imageio-plugins, info, invitation, item-selector, journal, knowledge-base, layout, license-manager, login, map, mentions, message-boards, microsoft-translator, mobile-device-rules, monitoring, nested-portlets, notifications, oauth2-provider, organizations, password-policies-admin, petra, plugins-admin, portal-background-task, portal-cache, portal-configuration, portal-instances, portal-language, portal-lock, portal-mobile-device-recognition, portal-odata, portal-osgi-debug, portal-portlet-bridge, portal-relationship, portal-remote, portal-reports-engine, portal-rules-engine, portal-scheduler, portal-scripting, portal-search-elasticsearch7, portal-search, portal-security-audit, portal-security-sso, portal-security, portal-settings, portal-store, portal-template, portal-url-builder, portal-validation, portal-vulcan, portal-workflow, portal, portlet-configuration, portlet-dependency-factory, portlet-display-template, product-navigation, questions, ratings, reading-time, redirect, remote-app, roles, rss, screens, segments, server, sharing, site-navigation, site, social, staging, style-book, subscription, text-localizer, translation, trash, upload, user-associated-data, user-groups-admin, users-admin, view-count, websocket, wiki, xstream
- LPS-98634 Fix the icon next to the field label
- LPS-98634 Make undraggable the map area
- LPS-130118 Push down persistence.jar
- LRAC-7729 Check if tracking is disabled before reset or dispose
- LPS-129912 Move responsibilities of state and onClick to TimeRangeFilter
- LPS-129912 Delete unnecessary hook
- LPS-130737 Fixing null pointer exception when there are no action providers
- LPS-130222 Add the SLA Results information for each instance
- LPS-130222 Sort by searchSearchRequest.*
- LPS-130744 Attach the annotation to the type instead of the parameter
- LPS-130744 Auto SF
- LPS-128053 Adds reducers for dataDefinition and dataLayout
- LPS-105380 Only check master
- LPS-105380 Add missing '.'
- LPS-105380 Fix typos and missing whitespace
- LPS-105380 Break strings in a cleaner way
- LRAC-7662 Create validators
- LRAC-7662 Prevent send invalid events
- LRAC-7662 SF
- LPS-129879 Adds the compatibility layer for App Builder
- LPS-129879 Integrates the Builder with the opening of the sidebar
- LPS-129879 Adding some properties to the schemas
- LPS-129879 Removing unnecessary compatibility layer properties
- LPS-129879 Implements the conversion and merge of fields with dataDefinitionFields
- LPS-129879 Add the mock of getDefaultLanguageId to the tests
- LPS-129879 SF
- LPS-129879 Fixes when starting the application when there is no data for dataDefinition and dataLayout
- LPS-129878 Create rulesReducer to data-engine structure
- LPS-129878 Create Rules Sidebar plugin
- LPS-129878 Adapt new components to use new data-engine structure
- LPS-129878 Format name to data-engine structure when get dataRules
- LPS-129878 SF
- LPS-129878 Get plugin entrypoint passing value as parameter
- LPS-129878 Remove unnecessary normalize rule
- LPS-129878 Create onSaveRule, onEditRule, onAddRule and onDeleteRule callbacks and save only loc instead of rule
- LPS-130744 prep next
- LPS-130744 prep next
- LPS-105380 Sort SearchContext.set* calls
- LPS-105380 Auto SF
- LPS-129452 Enable the edit of new assignee field
- LPS-129452 Add alias to assignee prop to make the code more clear
- LPS-129452 Always call onSelect if the assignee input changes
- subrepo:ignore Update 'modules/etl/mulesoft/.gitrepo'.
- LRQA-66642 - Move all P5 tests to relevant
- LRQA-66642 - Change the Workflow Metrics testcase component to Workflow Metrics
- LRQA-66642 - Remove Workflow Metrics and Kaleo Forms tests from ci:test:workflow suite
- LRQA-66642 - Remove Workflow Metrics and Kaleo Forms from the relevant suite of Worklfow
- LRQA-66642 - Add test.properties for Workflow Metrics folders
- LRQA-66642 - Add test.properties for the Kaleo Forms Admin folders
- LRQA-66642 - Add test.properties for Workflow Metrics folders on CE code
- LRQA-66642 - Create Workflow Metrics and Kaleo Forms test suites
- LRQA-66642 - SF
- LRQA-66642 - Quarantine tests
- LRQA-66642 - Fix WorkflowCEMetrics component
- LPS-130126 portal-kernel: all Inherited methods are now null safe
- LRQA-66100 Remove CP from macro
- LRQA-66100 Update tests to use renamed macros
- LRQA-66100 Move macro inside the only test case using it
- LRQA-66100 Move macro inside test
- LRQA-66100 Consolidate ViewApp and ViewStatus macros
- LRQA-66100 Replace with Guard Clause
- LRQA-66100 Move macro to testcase
- LRQA-66100 Rename tests to describe capability as opposed to what the test is performing
- LRQA-66100 Move var assertion right before the macro using it
- LRQA-66100 Use an existing macro
- LRQA-66100 Make consistent
- LRQA-66100 Test without the pause
- LRQA-66100 Use for loop
- LRQA-66107 Add new test that attempts to upload an invalid file
- LPS-130305 Add configuration compileIncludePlatform
- LPS-130305 prep next
- LPS-128297 Ensure that the taskTimers property is only displayed in TaskNodes
- LPS-128297 Allow timers propertie only in task nodes
- LPS-128297 Add Kaleo Timer instance tonkens only in TaskNodeExecutor
- LPS-128297 Add unit test for DefaultDueDateCalculator
- LPS-128297 Deprecate timer methods to other nodes
- LPS-128297 Rename TaskNodeExecutor to TaskNodeExecutorImpl
- LPS-128297 Create new executerTimer method
- LPS-128297 Apply to use
- LPS-128297 Create integration test for TaskNodeExecutorImpl
- LPS-128297 Simplify test
- LPS-128297 Make decrecated method default to avoid implement it in the sub classes
- LPS-128297 Do not expose a new interface just to satisfy the test integration dependency. Use reflection instead
- LPS-128297 Inline
- LPS-128297 Simplify integration tests by leveraging the WorkflowDefinitionManager API
- LPS-128297 Update to 7.4
- LPS-128297 Baseline
- LPS-128297 not needed
- LPS-128297 should this be 7.4?
- LPS-128297 inline
- LRQA-66684 Add portal-impl classes for release test run
- LPS-130595 Order SLA Results by the remaining time ASC
- LPS-128810 Adds new method to get the segments entry ids, since the experiences are related with the content page and we should use segmentEntryIds to filter the results. Also in collections admin App we are using segment entries to create the different varions and hot segment experiences.
- LPS-128810 Implements DefaultLayoutListRetrieverContext
- LPS-128810 Deprecate old methods, we should not use those methods anymore
- LPS-128810 Uses new method to get the segments entry ids
- LPS-128810 Uses new method to set the segmentsEntryIds and use the same code that we have in Asset Publisher to get the segmentEntryIds
- LPS-128810 We should show the collection without taking into account the experience. If we want to segment the result we should use the segment entry ids not the segment experiences, since the experiences is something related with the all page.
- LPS-128810 Update tests
- LPS-128810 baseline
- artifact:ignore portal-impl 7.0.1 prep next
- artifact:ignore portal-impl 7.0.1 releng
- artifact:ignore portal-kernel 10.5.1 prep next
- artifact:ignore portal-kernel 10.5.1 releng
- artifact:ignore portal-web 5.0.29 prep next
- artifact:ignore portal-web 5.0.29 releng
- build.gradle auto SF
- artifact:ignore bean-portlet-cdi-extension 4.0.1 change log
- artifact:ignore bean-portlet-cdi-extension 4.0.1 prep next
- artifact:ignore bean-portlet-cdi-extension 4.0.1 artifact properties
- artifact:ignore content-dashboard-web 2.0.5 change log
- artifact:ignore content-dashboard-web 2.0.5 prep next
- artifact:ignore content-dashboard-web 2.0.5 artifact properties
- artifact:ignore data-engine-taglib 3.0.8 change log
- artifact:ignore data-engine-taglib 3.0.8 prep next
- artifact:ignore data-engine-taglib 3.0.8 artifact properties
- artifact:ignore document-library-repository-authorization-api 5.1.1 change log
- artifact:ignore document-library-repository-authorization-api 5.1.1 prep next
- artifact:ignore document-library-repository-authorization-api 5.1.1 artifact properties
- artifact:ignore dynamic-data-mapping-expression 6.0.1 change log
- artifact:ignore dynamic-data-mapping-expression 6.0.1 prep next
- artifact:ignore dynamic-data-mapping-expression 6.0.1 artifact properties
- artifact:ignore dynamic-data-mapping-form-renderer 6.0.8 change log
- artifact:ignore dynamic-data-mapping-form-renderer 6.0.8 prep next
- artifact:ignore dynamic-data-mapping-form-renderer 6.0.8 artifact properties
- artifact:ignore dynamic-data-mapping-service 6.0.6 change log
- artifact:ignore dynamic-data-mapping-service 6.0.6 prep next
- artifact:ignore dynamic-data-mapping-service 6.0.6 artifact properties
- artifact:ignore dynamic-data-mapping-web 5.0.3 change log
- artifact:ignore dynamic-data-mapping-web 5.0.3 prep next
- artifact:ignore dynamic-data-mapping-web 5.0.3 artifact properties
- artifact:ignore fragment-service 4.0.4 change log
- artifact:ignore fragment-service 4.0.4 prep next
- artifact:ignore fragment-service 4.0.4 artifact properties
- artifact:ignore knowledge-base-web 5.0.5 change log
- artifact:ignore knowledge-base-web 5.0.5 prep next
- artifact:ignore knowledge-base-web 5.0.5 artifact properties
- artifact:ignore layout-api 7.1.0 change log
- artifact:ignore layout-api 7.1.0 prep next
- artifact:ignore layout-api 7.1.0 artifact properties
- artifact:ignore portal-user-locale-options-web 2.0.2 change log
- artifact:ignore portal-user-locale-options-web 2.0.2 prep next
- artifact:ignore portal-user-locale-options-web 2.0.2 artifact properties
- artifact:ignore portal-template-freemarker 7.0.2 change log
- artifact:ignore portal-template-freemarker 7.0.2 prep next
- artifact:ignore portal-template-freemarker 7.0.2 artifact properties
- artifact:ignore portal-vulcan-impl 5.0.5 change log
- artifact:ignore portal-vulcan-impl 5.0.5 prep next
- artifact:ignore portal-vulcan-impl 5.0.5 artifact properties
- artifact:ignore portal-workflow-kaleo-definition-api 6.0.1 change log
- artifact:ignore portal-workflow-kaleo-definition-api 6.0.1 prep next
- artifact:ignore portal-workflow-kaleo-definition-api 6.0.1 artifact properties
- artifact:ignore portal-workflow-metrics-sla-api 5.0.1 change log
- artifact:ignore portal-workflow-metrics-sla-api 5.0.1 prep next
- artifact:ignore portal-workflow-metrics-sla-api 5.0.1 artifact properties
- artifact:ignore segments-context-vocabulary 2.0.2 change log
- artifact:ignore segments-context-vocabulary 2.0.2 prep next
- artifact:ignore segments-context-vocabulary 2.0.2 artifact properties
- build.gradle auto SF
- artifact:ignore asset-list-item-selector-web 2.0.1 change log
- artifact:ignore asset-list-item-selector-web 2.0.1 prep next
- artifact:ignore asset-list-item-selector-web 2.0.1 artifact properties
- artifact:ignore commerce-product-service 6.0.4 change log
- artifact:ignore commerce-product-service 6.0.4 prep next
- artifact:ignore commerce-product-service 6.0.4 artifact properties
- artifact:ignore export-import-service 8.0.4 change log
- artifact:ignore export-import-service 8.0.4 prep next
- artifact:ignore export-import-service 8.0.4 artifact properties
- artifact:ignore fragment-web 4.0.3 change log
- artifact:ignore fragment-web 4.0.3 prep next
- artifact:ignore fragment-web 4.0.3 artifact properties
- artifact:ignore layout-taglib 6.0.6 change log
- artifact:ignore layout-taglib 6.0.6 prep next
- artifact:ignore layout-taglib 6.0.6 artifact properties
- artifact:ignore portal-workflow-kaleo-runtime-api 6.2.0 change log
- artifact:ignore portal-workflow-kaleo-runtime-api 6.2.0 prep next
- artifact:ignore portal-workflow-kaleo-runtime-api 6.2.0 artifact properties
- artifact:ignore product-navigation-control-menu-web 6.0.3 change log
- artifact:ignore product-navigation-control-menu-web 6.0.3 prep next
- artifact:ignore product-navigation-control-menu-web 6.0.3 artifact properties
- build.gradle auto SF
- artifact:ignore layout-admin-web 5.0.7 change log
- artifact:ignore layout-admin-web 5.0.7 prep next
- artifact:ignore layout-admin-web 5.0.7 artifact properties
- artifact:ignore layout-content-page-editor-web 3.0.12 change log
- artifact:ignore layout-content-page-editor-web 3.0.12 prep next
- artifact:ignore layout-content-page-editor-web 3.0.12 artifact properties
- artifact:ignore portal-workflow-kaleo-runtime-impl 6.0.3 change log
- artifact:ignore portal-workflow-kaleo-runtime-impl 6.0.3 prep next
- artifact:ignore portal-workflow-kaleo-runtime-impl 6.0.3 artifact properties
- artifact:ignore portal-workflow-kaleo-service 6.0.3 change log
- artifact:ignore portal-workflow-kaleo-service 6.0.3 prep next
- artifact:ignore portal-workflow-kaleo-service 6.0.3 artifact properties
- artifact:ignore product-navigation-product-menu-web 6.0.2 change log
- artifact:ignore product-navigation-product-menu-web 6.0.2 prep next
- artifact:ignore product-navigation-product-menu-web 6.0.2 artifact properties
- build.gradle auto SF
- artifact:ignore portal-workflow-kaleo-designer-web 5.0.3 change log
- artifact:ignore portal-workflow-kaleo-designer-web 5.0.3 prep next
- artifact:ignore portal-workflow-kaleo-designer-web 5.0.3 artifact properties
- artifact:ignore portal-workflow-kaleo-forms-api 5.0.1 change log
- artifact:ignore portal-workflow-kaleo-forms-api 5.0.1 prep next
- artifact:ignore portal-workflow-kaleo-forms-api 5.0.1 artifact properties
- artifact:ignore portal-workflow-kaleo-forms-lang 5.0.3 change log
- artifact:ignore portal-workflow-kaleo-forms-lang 5.0.3 prep next
- artifact:ignore portal-workflow-kaleo-forms-lang 5.0.3 artifact properties
- artifact:ignore portal-workflow-metrics-api 4.0.1 change log
- artifact:ignore portal-workflow-metrics-api 4.0.1 prep next
- artifact:ignore portal-workflow-metrics-api 4.0.1 artifact properties
- artifact:ignore portal-workflow-metrics-lang 3.0.3 change log
- artifact:ignore portal-workflow-metrics-lang 3.0.3 prep next
- artifact:ignore portal-workflow-metrics-lang 3.0.3 artifact properties
- artifact:ignore portal-workflow-metrics-rest-api 8.0.1 change log
- artifact:ignore portal-workflow-metrics-rest-api 8.0.1 prep next
- artifact:ignore portal-workflow-metrics-rest-api 8.0.1 artifact properties
- artifact:ignore portal-workflow-metrics-rest-client 3.0.2 change log
- artifact:ignore portal-workflow-metrics-rest-client 3.0.2 prep next
- artifact:ignore portal-workflow-metrics-rest-client 3.0.2 artifact properties
- artifact:ignore portal-workflow-metrics-web 3.0.4 change log
- artifact:ignore portal-workflow-metrics-web 3.0.4 prep next
- artifact:ignore portal-workflow-metrics-web 3.0.4 artifact properties
- build.gradle auto SF
- artifact:ignore portal-workflow-kaleo-forms-service 5.0.3 change log
- artifact:ignore portal-workflow-kaleo-forms-service 5.0.3 prep next
- artifact:ignore portal-workflow-kaleo-forms-service 5.0.3 artifact properties
- artifact:ignore portal-workflow-metrics-demo-data-creator-api 2.0.1 change log
- artifact:ignore portal-workflow-metrics-demo-data-creator-api 2.0.1 prep next
- artifact:ignore portal-workflow-metrics-demo-data-creator-api 2.0.1 artifact properties
- artifact:ignore portal-workflow-metrics-rest-spi 3.0.1 change log
- artifact:ignore portal-workflow-metrics-rest-spi 3.0.1 prep next
- artifact:ignore portal-workflow-metrics-rest-spi 3.0.1 artifact properties
- artifact:ignore portal-workflow-metrics-service 3.0.2 change log
- artifact:ignore portal-workflow-metrics-service 3.0.2 prep next
- artifact:ignore portal-workflow-metrics-service 3.0.2 artifact properties
- build.gradle auto SF
- artifact:ignore portal-workflow-kaleo-forms-web 5.0.2 change log
- artifact:ignore portal-workflow-kaleo-forms-web 5.0.2 prep next
- artifact:ignore portal-workflow-kaleo-forms-web 5.0.2 artifact properties
- artifact:ignore portal-workflow-kaleo-metrics-integration 2.0.1 change log
- artifact:ignore portal-workflow-kaleo-metrics-integration 2.0.1 prep next
- artifact:ignore portal-workflow-kaleo-metrics-integration 2.0.1 artifact properties
- artifact:ignore portal-workflow-metrics-demo 2.0.1 change log
- artifact:ignore portal-workflow-metrics-demo 2.0.1 prep next
- artifact:ignore portal-workflow-metrics-demo 2.0.1 artifact properties
- artifact:ignore portal-workflow-metrics-demo-data-creator-impl 2.0.1 change log
- artifact:ignore portal-workflow-metrics-demo-data-creator-impl 2.0.1 prep next
- artifact:ignore portal-workflow-metrics-demo-data-creator-impl 2.0.1 artifact properties
- artifact:ignore portal-workflow-metrics-rest-impl 3.0.2 change log
- artifact:ignore portal-workflow-metrics-rest-impl 3.0.2 prep next
- artifact:ignore portal-workflow-metrics-rest-impl 3.0.2 artifact properties
- build.gradle auto SF
- LPS-130468 Add step to agree to terms and answer reminder query
- LPS-130468 Add missing steps
- LPS-130468 Modify parameters
- LPS-130252 Migrate cases related to Grid to own folder
- Revert "LPS-129452 Always call onSelect if the assignee input changes"
- Revert "LPS-129452 Add alias to assignee prop to make the code more clear"
- Revert "LPS-129452 Enable the edit of new assignee field"
- LPS-130760
- LPS-130760 baseline
- LRQA-62432 Add portlet to test Alert Toast Message
- LRQA-62432 Add .lfrbuild-releng-ignore file to test portlet
- LPS-130540 Add macro to get categoryId by name via JSONWS
- LPS-130540 Add if to add category in non-default site
- LPS-130540 Refactor cases in Breadcrumb
- LPS-130540 Refactor cases in ProductMenu
- LPS-130540 Refactor cases in ApplicationsMenu
- LRQA-66697 Update case for navigating to tag admin
- LRQA-66698 Add relevant component
- LPS-130252 Migrate cases related to Grid to own folder
- LPS-130468 Modify locator to make it reusable
- LPS-130468 Use searchCP macro
- LRQA-66690 Modify case to assert displayed content
- LRQA-66690 Remove duplicate case
- LRQA-66690 Migrate cases
- LRQA-66690 Modify fragment codes
- LRQA-66690 Simplify cases
- LRQA-66690 Remove deprecated files
- LPS-130313 Add case to AddSegmentBySessionBrowser
- LPS-130314 Modify macro and add path to add property with 2 fields
- LPS-130314 Add case to AddSegmentBySessionCookies
- LPS-130314 Remove unnecessary click in macro
- LPS-130315 Add case to AddSegmentBySessionDeviceBrand
- LPS-130316 Add case to AddSegmentBySessionDeviceModel
- LPS-130317 Modify macro and path to add property with resolution field
- LPS-130317 Add case to AddSegmentBySessionDeviceScreenResolutionHeight
- LPS-130318 Add case to AddSegmentBySessionDeviceScreenResolutionWidth
- LPS-130318 Use lowerCamelCase in variables
- LPS-130269 Remove ignore to run these cases
- LPS-128852 Do not use registered from outside StoreFactory serviceTracker since race condition can still occur.
- LPS-128852 Eagerly instantiate as soon as outer class is loaded so waiting until outer get* methods isn't needed to create the inner serviceTracker.
- LPS-128852 Wait until StoreFactory is ready.
- LPS-128852 SF
- LPS-128852 SF
- LPS-130609 prefix and suffix are not exported to LDAP
- LPS-130609 avoid maps, it's only 2 items and there's actually less code duplication/round about thinking this way
- LPS-77699 Update Translations
- COMMERCE-6063 Adding RemoveAProductRelations Test
- COMMERCE-6017 Adding CreateAnOptionForAllTheFieldType Test
- COMMERCE-6017 SF
- LPS-130714 Ignore Forms#SubmitFormWithRequiredConfirmationTextField Poshi test
- LPS-119066 Call pagespeed inside getLayoutReportsIssues in LayoutReportsDataProvider:
- LPS-119066 New Resource Command that retrieve the list of LayoutReportsIssues given a URL.
- LPS-119066 Build lang
- LPS-119066 Hugo SF, I had to do this manually
- LPS-119066 wordsmith
- LPS-119066 regen
- LPS-119066 buy space
- artifact:ignore portal-impl 7.0.2 prep next
- artifact:ignore portal-impl 7.0.2 releng
- artifact:ignore portal-kernel 10.6.0 prep next
- artifact:ignore portal-kernel 10.6.0 releng
- artifact:ignore portal-web 5.0.30 prep next
- artifact:ignore portal-web 5.0.30 releng
- build.gradle auto SF
- artifact:ignore account-lang 2.0.2 change log
- artifact:ignore account-lang 2.0.2 prep next
- artifact:ignore account-lang 2.0.2 artifact properties
- artifact:ignore adaptive-media-web 5.0.3 change log
- artifact:ignore adaptive-media-web 5.0.3 prep next
- artifact:ignore adaptive-media-web 5.0.3 artifact properties
- artifact:ignore commerce-lang 4.0.7 change log
- artifact:ignore commerce-lang 4.0.7 prep next
- artifact:ignore commerce-lang 4.0.7 artifact properties
- artifact:ignore configuration-admin-web 5.0.5 change log
- artifact:ignore configuration-admin-web 5.0.5 prep next
- artifact:ignore configuration-admin-web 5.0.5 artifact properties
- artifact:ignore connected-app-web 3.0.2 change log
- artifact:ignore connected-app-web 3.0.2 prep next
- artifact:ignore connected-app-web 3.0.2 artifact properties
- artifact:ignore contacts-web 5.0.4 change log
- artifact:ignore contacts-web 5.0.4 prep next
- artifact:ignore contacts-web 5.0.4 artifact properties
- artifact:ignore content-dashboard-web 2.0.6 change log
- artifact:ignore content-dashboard-web 2.0.6 prep next
- artifact:ignore content-dashboard-web 2.0.6 artifact properties
- artifact:ignore data-cleanup 2.0.3 change log
- artifact:ignore data-cleanup 2.0.3 prep next
- artifact:ignore data-cleanup 2.0.3 artifact properties
- artifact:ignore data-engine-lang 3.0.7 change log
- artifact:ignore data-engine-lang 3.0.7 prep next
- artifact:ignore data-engine-lang 3.0.7 artifact properties
- artifact:ignore document-library-api 7.0.2 change log
- artifact:ignore document-library-api 7.0.2 prep next
- artifact:ignore document-library-api 7.0.2 artifact properties
- artifact:ignore document-library-asset-auto-tagger-google-cloud-vision 3.0.2 change log
- artifact:ignore document-library-asset-auto-tagger-google-cloud-vision 3.0.2 prep next
- artifact:ignore document-library-asset-auto-tagger-google-cloud-vision 3.0.2 artifact properties
- artifact:ignore document-library-asset-auto-tagger-microsoft-cognitive-services 3.0.2 change log
- artifact:ignore document-library-asset-auto-tagger-microsoft-cognitive-services 3.0.2 prep next
- artifact:ignore document-library-asset-auto-tagger-microsoft-cognitive-services 3.0.2 artifact properties
- artifact:ignore document-library-asset-auto-tagger-tensorflow 3.0.3 change log
- artifact:ignore document-library-asset-auto-tagger-tensorflow 3.0.3 prep next
- artifact:ignore document-library-asset-auto-tagger-tensorflow 3.0.3 artifact properties
- artifact:ignore document-library-google-drive-api 3.0.2 change log
- artifact:ignore document-library-google-drive-api 3.0.2 prep next
- artifact:ignore document-library-google-drive-api 3.0.2 artifact properties
- artifact:ignore layout-content-page-editor-web 3.0.13 change log
- artifact:ignore layout-content-page-editor-web 3.0.13 prep next
- artifact:ignore layout-content-page-editor-web 3.0.13 artifact properties
- artifact:ignore password-policies-admin-web 5.0.3 change log
- artifact:ignore password-policies-admin-web 5.0.3 prep next
- artifact:ignore password-policies-admin-web 5.0.3 artifact properties
- artifact:ignore portal-async-advice 3.0.3 change log
- artifact:ignore portal-async-advice 3.0.3 prep next
- artifact:ignore portal-async-advice 3.0.3 artifact properties
- artifact:ignore portal-cache-multiple 5.0.2 change log
- artifact:ignore portal-cache-multiple 5.0.2 prep next
- artifact:ignore portal-cache-multiple 5.0.2 artifact properties
- artifact:ignore portal-security-ldap-impl 4.0.1 change log
- artifact:ignore portal-security-ldap-impl 4.0.1 prep next
- artifact:ignore portal-security-ldap-impl 4.0.1 artifact properties
- artifact:ignore osgi-felix-lang 4.0.2 change log
- artifact:ignore osgi-felix-lang 4.0.2 prep next
- artifact:ignore osgi-felix-lang 4.0.2 artifact properties
- artifact:ignore portal-bundle-blacklist-impl 4.0.2 change log
- artifact:ignore portal-bundle-blacklist-impl 4.0.2 prep next
- artifact:ignore portal-bundle-blacklist-impl 4.0.2 artifact properties
- build.gradle auto SF
- artifact:ignore blogs-service 5.0.3 change log
- artifact:ignore blogs-service 5.0.3 prep next
- artifact:ignore blogs-service 5.0.3 artifact properties
- artifact:ignore document-library-service 6.0.5 change log
- artifact:ignore document-library-service 6.0.5 prep next
- artifact:ignore document-library-service 6.0.5 artifact properties
- artifact:ignore dynamic-data-mapping-service 6.0.7 change log
- artifact:ignore dynamic-data-mapping-service 6.0.7 prep next
- artifact:ignore dynamic-data-mapping-service 6.0.7 artifact properties
- artifact:ignore knowledge-base-service 5.0.3 change log
- artifact:ignore knowledge-base-service 5.0.3 prep next
- artifact:ignore knowledge-base-service 5.0.3 artifact properties
- build.gradle auto SF
- artifact:ignore analytics-reports-web 2.0.4 change log
- artifact:ignore analytics-reports-web 2.0.4 prep next
- artifact:ignore analytics-reports-web 2.0.4 artifact properties
- artifact:ignore commerce-punchout-oauth2-provider-rest 4.0.3 change log
- artifact:ignore commerce-punchout-oauth2-provider-rest 4.0.3 prep next
- artifact:ignore commerce-punchout-oauth2-provider-rest 4.0.3 artifact properties
- artifact:ignore commerce-punchout-portal-security-auto-login 4.0.2 change log
- artifact:ignore commerce-punchout-portal-security-auto-login 4.0.2 prep next
- artifact:ignore commerce-punchout-portal-security-auto-login 4.0.2 artifact properties
- artifact:ignore portal-workflow-metrics-web 3.0.5 prep next
- artifact:ignore portal-workflow-metrics-web 3.0.5 artifact properties
- build.gradle auto SF
- Revert "7.4.0 GA1 Release Apps: account, adaptive-media, address, alloy, analytics, announcements, app-builder, application-list, asset, batch-engine, bean-portlet, blogs, bulk, calendar, captcha, change-tracking, changeset, comment, commerce, configuration-admin, connected-app, contacts, content-dashboard, data-cleanup, data-engine, depot, dispatch, document-library-opener, document-library, dynamic-data-lists, dynamic-data-mapping, expando, export-import, external-reference, flags, fragment, friendly-url, frontend-css, frontend-editor, frontend-js, frontend-taglib, frontend-theme, frontend-token, gogo-shell, headless, iframe, image-uploader, imageio-plugins, info, invitation, item-selector, journal, knowledge-base, layout, license-manager, login, map, mentions, message-boards, microsoft-translator, mobile-device-rules, monitoring, nested-portlets, notifications, oauth2-provider, organizations, password-policies-admin, petra, plugins-admin, portal-background-task, portal-cache, portal-configuration, portal-instances, portal-language, portal-lock, portal-mobile-device-recognition, portal-odata, portal-osgi-debug, portal-portlet-bridge, portal-relationship, portal-remote, portal-reports-engine, portal-rules-engine, portal-scheduler, portal-scripting, portal-search-elasticsearch7, portal-search, portal-security-audit, portal-security-sso, portal-security, portal-settings, portal-store, portal-template, portal-url-builder, portal-validation, portal-vulcan, portal-workflow, portal, portlet-configuration, portlet-dependency-factory, portlet-display-template, product-navigation, questions, ratings, reading-time, redirect, remote-app, roles, rss, screens, segments, server, sharing, site-navigation, site, social, staging, style-book, subscription, text-localizer, translation, trash, upload, user-associated-data, user-groups-admin, users-admin, view-count, websocket, wiki, xstream"
- artifact:ignore document-library-repository-cmis-impl 6.0.1 prep next
- artifact:ignore document-library-repository-cmis-impl 6.0.1 artifact properties
- document-library-repository-cmis-impl 6.0.1 apply
- artifact:ignore document-library-sync-service 4.0.2 prep next
- artifact:ignore document-library-sync-service 4.0.2 artifact properties
- artifact:ignore saml-persistence-service 5.0.4 prep next
- artifact:ignore saml-persistence-service 5.0.4 artifact properties
- artifact:ignore document-library-repository-external-api 5.0.1 prep next
- artifact:ignore document-library-repository-external-api 5.0.1 artifact properties
- 7.4.0 GA1 Release Apps: account, adaptive-media, address, alloy, analytics, announcements, app-builder, application-list, asset, batch-engine, bean-portlet, blogs, bulk, calendar, captcha, change-tracking, changeset, comment, commerce, configuration-admin, connected-app, contacts, content-dashboard, data-cleanup, data-engine, depot, dispatch, document-library-opener, document-library, dynamic-data-lists, dynamic-data-mapping, expando, export-import, external-reference, flags, fragment, friendly-url, frontend-css, frontend-editor, frontend-js, frontend-taglib, frontend-theme, frontend-token, gogo-shell, headless, iframe, image-uploader, imageio-plugins, info, invitation, item-selector, journal, knowledge-base, layout, license-manager, login, map, mentions, message-boards, microsoft-translator, mobile-device-rules, monitoring, nested-portlets, notifications, oauth2-provider, organizations, password-policies-admin, petra, plugins-admin, portal-background-task, portal-cache, portal-configuration, portal-instances, portal-language, portal-lock, portal-mobile-device-recognition, portal-odata, portal-osgi-debug, portal-portlet-bridge, portal-relationship, portal-remote, portal-reports-engine, portal-rules-engine, portal-scheduler, portal-scripting, portal-search-elasticsearch7, portal-search, portal-security-audit, portal-security-sso, portal-security, portal-settings, portal-store, portal-template, portal-url-builder, portal-validation, portal-vulcan, portal-workflow, portal, portlet-configuration, portlet-dependency-factory, portlet-display-template, product-navigation, questions, ratings, reading-time, redirect, remote-app, roles, rss, screens, segments, server, sharing, site-navigation, site, social, staging, style-book, subscription, text-localizer, translation, trash, upload, user-associated-data, user-groups-admin, users-admin, view-count, websocket, wiki, xstream
- LPS-121091 Don't lock com.liferay.portal artifacts
- Revert "LRQA-66321 Temporarily quarantine WorkflowTaskManagerImplTest from search test suite"
- COMMERCE-6101 Adding UseSearchBar Test
- COMMERCE-6101 SF
- COMMERCE-6018 Adding CreateProductBundleWithPriceTypeStatic Test
- COMMERCE-6018 SF
- COMMERCE-6109 Adding EditAuthorizePaymentMethod Test
- COMMERCE-6109 SF
- COMMERCE-6064 Adding EditAProductRelations Test
- COMMERCE-6064 SF
- COMMERCE-6110 Adding AddShippingOptionVariableRate Test
- COMMERCE-6110 SF
- COMMERCE-6020 Adding AssertProductBundleCanBeCreatedWithPriceTypeStaticAndDynamic Test
- COMMERCE-6020 SF
- COMMERCE-6025 Adding AddAnImage Test
- COMMERCE-6025 SF
- LPS-129409 Create and apply PortalPreferencesCacheUtil to replace PortalPreferencesWrapperCacheUtil. After LPS-84374, we do not need cache values to be mvcc enabled. Later, we may want a more general solution for populating the finder cache for these list type model updates.
- LPS-129409 Remove extra update call since there are no model listeners for PortalPreferences.
- LPS-129800 Adds portlet id as namespace, since if we have portlet.container.restrict=false we are going to share the request attributes. So if we have more than one Web Content Display in the same page we are going to have the same JournalContentDisplayContext for all Web Content Displays.
- LPS-129800 Removes unused method
- LPS-129800 Add #
- LRCI-2173 Find test results from childReports if they are available
- LRCI-2142 Add a minimum duration time to help filter results in duration report
- LRCI-2142 Make slashes flexible in regex for top level build url
- LRCI-2142 prep next
- LPS-130868 Implement default DataDefinitionContentType
