### PR TITLE
LPS-130971 Adding spaces to predefinedValue field of Documents and Media field causes Javascript exception

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/io/util/DDMFormFieldSerializerUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/io/util/DDMFormFieldSerializerUtil.java
@@ -25,11 +25,13 @@ import com.liferay.dynamic.data.mapping.model.DDMFormFieldValidation;
 import com.liferay.dynamic.data.mapping.model.DDMFormFieldValidationExpression;
 import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.dynamic.data.mapping.util.DDMFormFactory;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.List;
 import java.util.Locale;
@@ -117,6 +119,8 @@ public class DDMFormFieldSerializerUtil {
 		List<DDMFormField> ddmFormFields,
 		DDMFormFieldTypeServicesTracker ddmFormFieldTypeServicesTracker,
 		JSONFactory jsonFactory) {
+
+		_trimEmptyValues(ddmFormFields);
 
 		JSONArray jsonArray = jsonFactory.createJSONArray();
 
@@ -302,6 +306,45 @@ public class DDMFormFieldSerializerUtil {
 		}
 
 		return jsonObject;
+	}
+
+	private static LocalizedValue _trim(LocalizedValue rawLocalizedValue) {
+		Map<Locale, String> predefinedValuesMap = rawLocalizedValue.getValues();
+
+		LocalizedValue localizedValue = new LocalizedValue();
+
+		for (Map.Entry<Locale, String> entry : predefinedValuesMap.entrySet()) {
+			String value = entry.getValue();
+
+			value = StringUtil.trim(value);
+
+			if (value.length() == 0) {
+				localizedValue.addString(entry.getKey(), StringPool.BLANK);
+			}
+			else {
+				localizedValue.addString(entry.getKey(), entry.getValue());
+			}
+		}
+
+		return localizedValue;
+	}
+
+	private static void _trimEmptyValues(List<DDMFormField> ddmFormFields) {
+		LocalizedValue localizedValue;
+
+		for (DDMFormField ddmFormField : ddmFormFields) {
+			localizedValue = _trim(ddmFormField.getPredefinedValue());
+
+			ddmFormField.setPredefinedValue(localizedValue);
+
+			localizedValue = _trim(ddmFormField.getStyle());
+
+			ddmFormField.setStyle(localizedValue);
+
+			localizedValue = _trim(ddmFormField.getTip());
+
+			ddmFormField.setTip(localizedValue);
+		}
 	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/io/util/DDMFormFieldSerializerUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/io/util/DDMFormFieldSerializerUtil.java
@@ -309,6 +309,10 @@ public class DDMFormFieldSerializerUtil {
 	}
 
 	private static LocalizedValue _trim(LocalizedValue rawLocalizedValue) {
+		if (rawLocalizedValue == null) {
+			return rawLocalizedValue;
+		}
+
 		Map<Locale, String> predefinedValuesMap = rawLocalizedValue.getValues();
 
 		LocalizedValue localizedValue = new LocalizedValue();
@@ -330,20 +334,22 @@ public class DDMFormFieldSerializerUtil {
 	}
 
 	private static void _trimEmptyValues(List<DDMFormField> ddmFormFields) {
-		LocalizedValue localizedValue;
+		if (!ddmFormFields.isEmpty()) {
+			LocalizedValue localizedValue;
 
-		for (DDMFormField ddmFormField : ddmFormFields) {
-			localizedValue = _trim(ddmFormField.getPredefinedValue());
+			for (DDMFormField ddmFormField : ddmFormFields) {
+				localizedValue = _trim(ddmFormField.getPredefinedValue());
 
-			ddmFormField.setPredefinedValue(localizedValue);
+				ddmFormField.setPredefinedValue(localizedValue);
 
-			localizedValue = _trim(ddmFormField.getStyle());
+				localizedValue = _trim(ddmFormField.getStyle());
 
-			ddmFormField.setStyle(localizedValue);
+				ddmFormField.setStyle(localizedValue);
 
-			localizedValue = _trim(ddmFormField.getTip());
+				localizedValue = _trim(ddmFormField.getTip());
 
-			ddmFormField.setTip(localizedValue);
+				ddmFormField.setTip(localizedValue);
+			}
 		}
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/io/util/DDMFormFieldSerializerUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/io/util/DDMFormFieldSerializerUtil.java
@@ -310,7 +310,7 @@ public class DDMFormFieldSerializerUtil {
 
 	private static LocalizedValue _trim(LocalizedValue rawLocalizedValue) {
 		if (rawLocalizedValue == null) {
-			return rawLocalizedValue;
+			return null;
 		}
 
 		Map<Locale, String> predefinedValuesMap = rawLocalizedValue.getValues();
@@ -320,10 +320,15 @@ public class DDMFormFieldSerializerUtil {
 		for (Map.Entry<Locale, String> entry : predefinedValuesMap.entrySet()) {
 			String value = entry.getValue();
 
-			value = StringUtil.trim(value);
+			if (value != null) {
+				value = StringUtil.trim(value);
 
-			if (value.length() == 0) {
-				localizedValue.addString(entry.getKey(), StringPool.BLANK);
+				if (value.length() == 0) {
+					localizedValue.addString(entry.getKey(), StringPool.BLANK);
+				}
+				else {
+					localizedValue.addString(entry.getKey(), entry.getValue());
+				}
 			}
 			else {
 				localizedValue.addString(entry.getKey(), entry.getValue());


### PR DESCRIPTION
Hi !
Could you please review this pull request?
The definition of the structure can contains values ​​that contain unnecessary spaces after saving that can later mess up the operation of the portal. I want to prevent this with that fix.
More info [here](https://issues.liferay.com/browse/LPP-40924?focusedCommentId=2423403&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2423403)

Thank you and best regards,
Marci