### PR TITLE
LPS-129592 Migrate ItemSelectorDialog to openSelectionModal in DDM modules

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DocumentLibrary/DocumentLibrary.es.js
@@ -24,7 +24,6 @@ import {
 	useConfig,
 	useFormState,
 } from 'dynamic-data-mapping-form-renderer';
-import {ItemSelectorDialog} from 'frontend-js-web';
 import React, {useEffect, useMemo, useState} from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
@@ -254,6 +253,8 @@ const GuestUploadFile = ({
 };
 
 const Main = ({
+	_onBlur,
+	_onFocus,
 	allowGuestUsers,
 	displayErrors: initialDisplayErrors,
 	editingLanguageId,
@@ -268,9 +269,7 @@ const Main = ({
 	maximumSubmissionLimitReached,
 	message,
 	name,
-	onBlur,
 	onChange,
-	onFocus,
 	placeholder,
 	readOnly,
 	valid: initialValid,
@@ -336,38 +335,20 @@ const Main = ({
 		return repetitionsCounter === maximumRepetitions;
 	};
 
-	const handleVisibleChange = (event) => {
-		if (event.selectedItem) {
-			onFocus({}, event);
-		}
-		else {
-			onBlur({}, event);
-		}
-	};
+	const handleFieldChanged = (selectedItem) => {
+		if (selectedItem?.value) {
+			setCurrentValue(selectedItem.value);
 
-	const handleFieldChanged = (event) => {
-		const selectedItem = event.selectedItem;
-
-		if (selectedItem) {
-			const {value} = selectedItem;
-
-			setCurrentValue(value);
-
-			onChange(event, value);
+			onChange(selectedItem, selectedItem.value);
 		}
 	};
 
 	const handleSelectButtonClicked = ({portletNamespace}) => {
-		const itemSelectorDialog = new ItemSelectorDialog({
-			eventName: `${portletNamespace}selectDocumentLibrary`,
-			singleSelect: true,
+		Liferay.Util.openSelectionModal({
+			onSelect: handleFieldChanged,
+			selectEventName: `${portletNamespace}selectDocumentLibrary`,
 			url: itemSelectorURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', handleFieldChanged);
-		itemSelectorDialog.on('visibleChange', handleVisibleChange);
-
-		itemSelectorDialog.open();
 	};
 
 	const configureErrorMessage = (message) => {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -15,7 +15,6 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayModal, {useModal} from '@clayui/modal';
-import {ItemSelectorDialog} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
@@ -54,13 +53,12 @@ const ImagePicker = ({
 			return mergedValues;
 		});
 
-	const handleFieldChanged = (event) => {
-		const selectedItem = event.selectedItem;
+	const handleFieldChanged = (selectedItem) => {
+		if (selectedItem?.value) {
+			const selectedImage = new Image();
+			const selectedItemValue = JSON.parse(selectedItem.value);
 
-		if (selectedItem && selectedItem.value) {
-			const img = new Image();
-			const item = JSON.parse(selectedItem.value);
-			img.addEventListener('load', (event) => {
+			selectedImage.addEventListener('load', (event) => {
 				const {
 					target: {height, width},
 				} = event;
@@ -74,29 +72,25 @@ const ImagePicker = ({
 						url: '',
 						width,
 					},
-					...item,
+					...selectedItemValue,
 				};
 
 				dispatchValue({value: imageData}, (mergedValues) =>
 					onFieldChanged(mergedValues)
 				);
 			});
-			img.src = item.url;
+			selectedImage.src = selectedItemValue.url;
 		}
 	};
 
 	const handleItemSelectorTriggerClick = (event) => {
 		event.preventDefault();
 
-		const itemSelectorDialog = new ItemSelectorDialog({
-			eventName: `${portletNamespace}selectDocumentLibrary`,
-			singleSelect: true,
+		Liferay.Util.openSelectionModal({
+			onSelect: handleFieldChanged,
+			selectEventName: `${portletNamespace}selectDocumentLibrary`,
 			url: itemSelectorURL,
 		});
-
-		itemSelectorDialog.on('selectedItemChange', handleFieldChanged);
-
-		itemSelectorDialog.open();
 	};
 
 	const placeholder = readOnly


### PR DESCRIPTION
A part of our ongoing migration of [selection modals epic](https://issues.liferay.com/browse/LPS-129246). Here I'm migrating `ItemSelectorDialog` by replacing it with `openSelectionModal`.

# 🧪 Test Cases
## `ImagePicker.es.js`

1. Under Content & Data go to Forms
2. Create a form with the Image element
3. Publish and put that form on the landing page
4. Click on Select to select images you’ve uploaded

## `DocumentLibrary.es.js`

1. Under Content & Data go to Forms
2. Create a form with the Upload element
3. Publish and put that form on the landing page
4. Click on Select to select files you’ve uploaded

⚠️ I've removed the `itemSelectorDialog.on('visibleChange', handleVisibleChange);` handling because I didn't notice it doing anything, so please test this if it's not leftover code from some bygone time.