### PR TITLE
LPS-131912 if value is not localized, the value for all the available locales is overwritten

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormValuesToFieldsConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormValuesToFieldsConverterImpl.java
@@ -229,7 +229,7 @@ public class DDMFormValuesToFieldsConverterImpl
 					if (!locale.equals(availableLocale)) {
 						Value value = ddmFormFieldValue.getValue();
 
-						if (value != null) {
+						if ((value != null) && value.isLocalized()) {
 							Map<Locale, String> values = value.getValues();
 
 							if (values.get(availableLocale) == null) {


### PR DESCRIPTION
The custom tag property will be missing after the localization: (https://issues.liferay.com/browse/LPS-131912) :

https://issues.liferay.com/secure/attachment/404973/Pages%20-%20Test%20Site%20Name%20-%20Liferay%20-%20Google%20Chrome%202021-05-10%2013-26-40.mp4


The tags of the custom meta tags there are not localized values, and with the changes of https://issues.liferay.com/browse/LPS-130342 the values are overwritten by the default values (for all the availables locales)

I tested the changes with the issue https://issues.liferay.com/browse/LPS-130342 too and I think that it works too.

Thanks!: