### PR TITLE
LPS-131912 if value is not localized, the value for all the available locales is overwritten

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormValuesToFieldsConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormValuesToFieldsConverterImpl.java
@@ -221,8 +221,9 @@ public class DDMFormValuesToFieldsConverterImpl
 			boolean repeatableAncestor)
 		throws PortalException {
 
-		if (!StringUtil.equals(ddmFormField.getType(), "fieldset") &&
-			(ddmFormField.isRepeatable() || repeatableAncestor)) {
+		if (ddmFormField.isLocalizable() &&
+			(ddmFormField.isRepeatable() || repeatableAncestor) &&
+			!StringUtil.equals(ddmFormField.getType(), "fieldset")) {
 
 			availableLocales.forEach(
 				availableLocale -> {


### PR DESCRIPTION
Related ticket: https://issues.liferay.com/browse/LPS-131912

@AliciaGarciaGarcia,

Your idea seems to work, but I moved the "localizable" validation two `"ifs"` up to avoid having to iterate the available locales with no purpose.

Thanks for contributing.