### PR TITLE
[TS] LPS-131594 Get the site's default locale, so the non-localized date of fragment is formatted according to the default locale instead of the American format.

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/item/provider/DDMFormValuesInfoFieldValuesProviderImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/item/provider/DDMFormValuesInfoFieldValuesProviderImpl.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.DateUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.text.DateFormat;
@@ -208,6 +209,10 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 
 				if (Validator.isNull(valueString)) {
 					return null;
+				}
+
+				if (locale.equals(LocaleUtil.ROOT)) {
+					locale = LocaleUtil.getSiteDefault();
 				}
 
 				DateFormat dateFormat = DateFormat.getDateInstance(


### PR DESCRIPTION
Hi Team,

**Issue description:** After the default language of the site is changed from en_US and a non-localized date is displayed in a fragment, the date format is always going to be the American format.

**Fix:** in _sanitizeDDMFormFieldValue after we retrieved the string from the empty locale we change the locale to the site default locale.

I sent this solution for validation, please find more information on the **PTR**: https://issues.liferay.com/browse/PTR-2445
**LPS** with repro steps: https://issues.liferay.com/browse/LPS-131594

Please review it. Thank you!

