### PR TITLE
LPS-132437 Migrate dynamic data template selection modals

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+	compileOnly project(":apps:petra:petra-portlet-url-builder")
 	compileOnly project(":apps:portlet-display-template:portlet-display-template-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/init-ext.jspf
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/init-ext.jspf
@@ -20,7 +20,6 @@
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
-taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -18,8 +18,11 @@
 
 <%@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
-<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+<%@ page import="com.liferay.petra.portlet.url.builder.PortletURLBuilder" %><%@
+page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
+page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
+page import="com.liferay.portal.kernel.portlet.PortletURLFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.JavaConstants" %><%@
@@ -34,6 +37,8 @@ page import="java.util.List" %><%@
 page import="java.util.Locale" %><%@
 page import="java.util.Map" %><%@
 page import="java.util.Set" %>
+
+<%@ page import="javax.portlet.PortletRequest" %>
 
 <%@ include file="/init-ext.jspf" %>
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
@@ -94,42 +94,47 @@ Group ddmTemplateGroup = GroupLocalServiceUtil.getGroup(ddmTemplateGroupId);
 	</c:if>
 </clay:content-row>
 
-<liferay-portlet:renderURL plid="<%= themeDisplay.getPlid() %>" portletName="<%= PortletProviderUtil.getPortletId(DDMTemplate.class.getName(), PortletProvider.Action.VIEW) %>" var="basePortletURL">
-	<portlet:param name="showHeader" value="<%= Boolean.FALSE.toString() %>" />
-</liferay-portlet:renderURL>
+<%
+String manageDDMTemplatesURL = PortletURLBuilder.create(
+	PortletURLFactoryUtil.create(request, PortletProviderUtil.getPortletId(DDMTemplate.class.getName(), PortletProvider.Action.VIEW), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE)
+).setMVCPath(
+	"/view_template.jsp"
+).setParameter(
+	"classNameId", classNameId
+).setParameter(
+	"groupId", ddmTemplateGroupId
+).setParameter(
+	"navigationStartsOn", DDMNavigationHelper.VIEW_TEMPLATES
+).setParameter(
+	"refererPortletName", PortletKeys.PORTLET_DISPLAY_TEMPLATE
+).setParameter(
+	"showHeader", false
+).setWindowState(
+	LiferayWindowState.POP_UP
+).buildString();
+%>
 
 <aui:script sandbox="<%= true %>">
-	var selectDDMTemplateLink = document.getElementById(
+	const manageDDMTemplatesLink = document.getElementById(
 		'<portlet:namespace />selectDDMTemplate'
 	);
 
-	if (selectDDMTemplateLink) {
-		selectDDMTemplateLink.addEventListener('click', (event) => {
-			Liferay.Util.openDDMPortlet(
-				{
-					basePortletURL: '<%= basePortletURL %>',
-					classNameId: '<%= classNameId %>',
-					dialog: {
-						width: 1024,
-					},
-					eventName: '<portlet:namespace />saveTemplate',
-					groupId: <%= ddmTemplateGroupId %>,
-					mvcPath: '/view_template.jsp',
-					navigationStartsOn: '<%= DDMNavigationHelper.VIEW_TEMPLATES %>',
-					refererPortletName:
-						'<%= PortletKeys.PORTLET_DISPLAY_TEMPLATE %>',
-					title:
-						'<%= UnicodeLanguageUtil.get(request, "widget-templates") %>',
-				},
-				(event) => {
-					if (!event.newVal) {
-						submitForm(
-							document.<portlet:namespace />fm,
-							'<%= HtmlUtil.escapeJS(refreshURL) %>'
-						);
+	if (manageDDMTemplatesLink) {
+		manageDDMTemplatesLink.addEventListener('click', (event) => {
+			const openerWindow = Liferay.Util.getOpener();
+
+			openerWindow.Liferay.Util.openModal({
+				onClose: () => {
+					const form = document.getElementById('<portlet:namespace />fm');
+
+					if (form) {
+						submitForm(form, '<%= HtmlUtil.escapeJS(refreshURL) %>');
 					}
-				}
-			);
+				},
+				title:
+					'<%= UnicodeLanguageUtil.get(request, "widget-templates") %>',
+				url: '<%= manageDDMTemplatesURL %>',
+			});
 		});
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/select_template.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/select_template.jsp
@@ -21,7 +21,6 @@ long templateId = ParamUtil.getLong(request, "templateId");
 
 long classNameId = ParamUtil.getLong(request, "classNameId");
 long classPK = ParamUtil.getLong(request, "classPK");
-String eventName = ParamUtil.getString(request, "eventName", "selectTemplate");
 
 DDMStructure structure = null;
 
@@ -113,10 +112,3 @@ if ((classPK > 0) && (structureClassNameId == classNameId)) {
 		</liferay-ui:search-container>
 	</clay:container-fluid>
 </aui:form>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectTemplateFm',
-		'<%= HtmlUtil.escapeJS(eventName) %>'
-	);
-</aui:script>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/js/KaleoFormsTemplateSelector.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/js/KaleoFormsTemplateSelector.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import {
+	createRenderURL,
+	fetch,
+	navigate,
+	objectToFormData,
+	openSelectionModal,
+} from 'frontend-js-web';
+
+export default function ({
+	backURL,
+	itemSelectorURL,
+	portletNamespace,
+	saveInPortletSessionURL,
+}) {
+	window[`${portletNamespace}selectFormTemplate`] = (
+		classPK,
+		mode,
+		sessionParamName
+	) => {
+		const url = createRenderURL(itemSelectorURL, {
+			classPK,
+			mode,
+		});
+
+		openSelectionModal({
+			onSelect: (selectedItem) => {
+				const data = {};
+
+				data[sessionParamName] = selectedItem.ddmtemplateid;
+
+				fetch(saveInPortletSessionURL, {
+					body: objectToFormData(data),
+					method: 'POST',
+				}).then((response) => {
+					if (response.ok) {
+						navigate(decodeURIComponent(backURL));
+					}
+				});
+			},
+			selectEventName: 'selectStructure',
+			title: Liferay.Language.get('form'),
+			url: String(url),
+		});
+	};
+}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/task_template_search_container.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/task_template_search_container.jsp
@@ -107,61 +107,50 @@ KaleoTaskFormPair initialStateKaleoTaskFormPair = KaleoFormsUtil.getInitialState
 	</liferay-ui:search-container>
 </div>
 
+<portlet:resourceURL id="saveInPortletSession" var="saveInPortletSessionURL" />
+
+<%
+String itemSelectorURL = PortletURLBuilder.create(
+	PortletURLFactoryUtil.create(request, DDMPortletKeys.DYNAMIC_DATA_MAPPING, themeDisplay.getPlid(), PortletRequest.RENDER_PHASE)
+).setMVCPath(
+	"/select_template.jsp"
+).setParameter(
+	"classNameId", PortalUtil.getClassNameId(DDMStructure.class)
+).setParameter(
+	"navigationStartsOn", DDMNavigationHelper.SELECT_TEMPLATE
+).setParameter(
+	"portletResourceNamespace", liferayPortletResponse.getNamespace()
+).setParameter(
+	"refererPortletName", portletDisplay.getId()
+).setParameter(
+	"resourceClassNameId", scopeClassNameId
+).setParameter(
+	"showBackURL", false
+).setParameter(
+	"showHeader", false
+).setParameter(
+	"structureAvailableFields", liferayPortletResponse.getNamespace() + "getAvailableFields"
+).setWindowState(
+	LiferayWindowState.POP_UP
+).buildString();
+%>
+
+<liferay-frontend:component
+	context='<%=
+		HashMapBuilder.<String, Object>put(
+			"backURL", HtmlUtil.escapeURL(backURL)
+		).put(
+			"itemSelectorURL", itemSelectorURL
+		).put(
+			"portletNamespace", liferayPortletResponse.getNamespace()
+		).put(
+			"saveInPortletSessionURL", saveInPortletSessionURL
+		).build()
+	%>'
+	module="admin/js/KaleoFormsTemplateSelector"
+/>
+
 <aui:script use="aui-base,aui-io-request,liferay-util">
-	Liferay.provide(
-		window,
-		'<portlet:namespace />selectFormTemplate',
-		(classPK, mode, sessionParamName) => {
-			Liferay.Util.openDDMPortlet(
-				{
-					basePortletURL:
-						'<%= PortletURLFactoryUtil.create(request, DDMPortletKeys.DYNAMIC_DATA_MAPPING, themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>',
-					classNameId: <%= PortalUtil.getClassNameId(DDMStructure.class) %>,
-					classPK: classPK,
-					dialog: {
-						destroyOnHide: true,
-					},
-					id: 'ddmDialog',
-					mode: mode,
-					mvcPath: '/select_template.jsp',
-					navigationStartsOn:
-						'<%= DDMNavigationHelper.SELECT_TEMPLATE %>',
-					portletResourceNamespace:
-						'<%= liferayPortletResponse.getNamespace() %>',
-					refererPortletName: '<%= portletDisplay.getId() %>',
-					resourceClassNameId: <%= scopeClassNameId %>,
-					showBackURL: false,
-					showHeader: false,
-					structureAvailableFields:
-						'<%= liferayPortletResponse.getNamespace() + "getAvailableFields" %>',
-					title: '<liferay-ui:message key="form" />',
-				},
-				(event) => {
-					var A = AUI();
-
-					var data = {};
-
-					data[sessionParamName] = event.ddmtemplateid;
-
-					A.io.request(
-						'<portlet:resourceURL id="saveInPortletSession" />',
-						{
-							after: {
-								success: function () {
-									window.location = decodeURIComponent(
-										'<%= HtmlUtil.escapeURL(backURL) %>'
-									);
-								},
-							},
-							data: data,
-						}
-					);
-				}
-			);
-		},
-		['aui-base', 'aui-io-request', 'liferay-util']
-	);
-
 	Liferay.provide(
 		window,
 		'<portlet:namespace />editFormTemplate',


### PR DESCRIPTION
Hey @liferay-data-engine ,

This is a part of [an ongoing epic](https://issues.liferay.com/browse/LPS-129246) to replace legacy AUI-based modals with Clay/React-based `openSelectionModal`.  We have previously migrated DDM modals, in https://github.com/liferay-data-engine/liferay-portal/pull/407, but we were not aware of `openDDMPortlet` utilily. This PR is first of two tasks to migrate and deprecate this utility.

JIRA: https://issues.liferay.com/browse/LPS-132437

Notes:
- There are 5 uses of `openDDMPortlet`, 4 of which is a selection modal. One, in this PR, is not, and we are replacing it with `openModal`. This way we can cleanly deprecate the util at the end of the epic. 
- In this PR, we are slightly changing the appearance of modal in DDM taglib (asset publisher config). A custom fixed width (1024px) is not standard by [Lexicon](https://liferay.design/lexicon/core-components/modals/#size), instead we are choosing one of standard `size`s. For a complex modal content such as management toolbar and search container, it is standard to use a full screen modal, so I set it that way in this PR. Please see before and after gifs.
- As usual, we are taking the opportunity to modernize related code, and remove AUI.

Test case 1:
1. Content & Data > Kaleo Forms Admin > Add a new process
1. Follow workflow to step 4.
1. Task > (⋮) > Assign Form
1. Create a form if there are none
1. Select a form

After:
![after1](https://user-images.githubusercontent.com/5435511/119149887-38514e00-ba4e-11eb-9006-eb07a0e40c58.gif)

Test case 2:
1. Place Asset Publisher app in a page.
1. (⋮) > Configuration > Display Settings > Manage Templates
1. Create a new template.
1. Close modal
1. Confirm newly created template is available in dropdown

Before:
![before](https://user-images.githubusercontent.com/5435511/119149994-5454ef80-ba4e-11eb-9d3c-f078396e9401.gif)

After:
![after](https://user-images.githubusercontent.com/5435511/119150036-5ae36700-ba4e-11eb-9839-6bbf601bfd02.gif)

/cc @kresimir-coko @jonmak08