### PR TITLE
LPS-133183 This may be a blank string instead of null or undefined

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1274,7 +1274,7 @@ AUI.add(
 
 						if (
 							locale === defaultLocale ||
-							(localizationMap[defaultLocale] &&
+							(localizationMap[defaultLocale] !== undefined &&
 								value !== localizationMap[defaultLocale]) ||
 							localizationMap[locale]
 						) {


### PR DESCRIPTION
Hi @liferay-data-engine ,
Could you please review this pull request?

Steps to reproduce:

1. Start a vanilla master.
2. Create a web content structure with minimum 2 text fields and add a translation to it in any language (I used Hungarian, but also tested with Dutch before).
3. Start editing a new web content with the above created structure.
4. Fill out one of the fields.
5. Change the language to Hungarian and fill out the other field.
6. Publish the web content.
7. Open the published web content for editing and review the Hungarian translation.

Original pull: https://github.com/liferay/liferay-portal-ee/pull/23205
This issue was presented on the older branches but It turned out that fix was also needed for a master. 
Thank you and best regards,
Marci