### PR TITLE
LPS-133741 "There was an error when loading the "rich_text" field." display after translating to both ES and JP

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
@@ -73,7 +73,7 @@ const RichText = ({
 						onChange({}, data);
 					}
 					else if (!dirty) {
-						CKEDITOR.instances[name].resetUndo();
+						CKEDITOR.instances[name]?.resetUndo();
 					}
 				}}
 				onMode={({editor}) => {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-133741

Sometimes the CKEditor instance isn't ready and we try to call the resetUndo.
