### PR TITLE
LPS-132436 Remove unnecessary selectEntityHandler

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/select_structure.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/select_structure.jsp
@@ -19,7 +19,6 @@
 <%
 long classPK = ParamUtil.getLong(request, "classPK");
 String displayStyle = ParamUtil.getString(request, "displayStyle", "list");
-String eventName = ParamUtil.getString(request, "eventName", "selectStructure");
 
 SearchContainer<DDMStructure> structureSearch = ddmDisplayContext.getStructureSearch();
 %>
@@ -104,10 +103,3 @@ SearchContainer<DDMStructure> structureSearch = ddmDisplayContext.getStructureSe
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectStructureFm',
-		'<%= HtmlUtil.escapeJS(eventName) %>'
-	);
-</aui:script>


### PR DESCRIPTION
Hi @liferay-data-engine, this is a small PR to finish off this task. It just removes the leftover `selectEntityHandler` usage that is obsolete with the switch to `openSelectionModal`.