### PR TITLE
LPS-133834 Open sidebar by default

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/new-js/FormBuilder.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/new-js/FormBuilder.js
@@ -49,7 +49,7 @@ export const FormBuilder = () => {
 	} = useConfig();
 
 	const [{sidebarOpen, sidebarPanelId}, setSidebarState] = useState({
-		sidebarOpen: false,
+		sidebarOpen: true,
 		sidebarPanelId: 'fields',
 	});
 


### PR DESCRIPTION
Hey!

This pr activates the sidebar in places where the FormBuilder is used when the application starts. We usually open the sidebar by default in other portal apps like the page editor or web content. Let me know if this can't be done here for some reason

Thanks!