### PR TITLE
LPS-128735 Translation in CKEditor source mode is lost upon switching locales

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
@@ -47,9 +47,9 @@ const RichText = ({
 
 			editor.config.contentsLanguage = editingLanguageId;
 
-			editor.setData(editor.getData());
+			setCurrentValue(value);
 		}
-	}, [editingLanguageId, editorRef]);
+	}, [editingLanguageId, editorRef, setCurrentValue, value]);
 
 	return (
 		<FieldBase
@@ -62,7 +62,6 @@ const RichText = ({
 		>
 			<ClassicEditor
 				contents={currentValue}
-				data={currentValue}
 				editorConfig={editorConfig}
 				name={name}
 				onChange={(data) => {
@@ -76,19 +75,12 @@ const RichText = ({
 						CKEDITOR.instances[name]?.resetUndo();
 					}
 				}}
-				onMode={({editor}) => {
-					if (editor.mode === 'source') {
-						editor.on('afterSetData', ({data}) => {
-							const {dataValue} = data;
+				onSetData={({data}) => {
+					const {dataValue} = data;
 
-							setCurrentValue(dataValue);
+					setCurrentValue(dataValue);
 
-							onChange({}, dataValue);
-						});
-					}
-					else {
-						editor.removeListener('afterSetData');
-					}
+					onChange({}, dataValue);
 				}}
 				readOnly={readOnly}
 				ref={editorRef}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
@@ -16,7 +16,6 @@ import {ClassicEditor} from 'frontend-editor-ckeditor-web';
 import React, {useEffect, useRef, useState} from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
-import {useSyncValue} from '../hooks/useSyncValue.es';
 
 const RichText = ({
 	editingLanguageId,
@@ -30,7 +29,7 @@ const RichText = ({
 	visible,
 	...otherProps
 }) => {
-	const [currentValue, setCurrentValue] = useSyncValue(
+	const [currentValue, setCurrentValue] = useState(
 		value ? value : predefinedValue
 	);
 


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-128735
Related: https://issues.liferay.com/browse/PTR-2340

See steps to reproduce, description and discussions in above tickets.

We are fixing two separate bugs in this PR, in two commits:
1. Titular one, translation in CKEditor source mode is lost upon switching locales.
2. The behavior described in [this comment](https://issues.liferay.com/browse/LPS-128735?focusedCommentId=2464529&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2464529), unrelated to source mode, where the content sometimes does not update after switching locales.

Notes:
- The first bug is caused by the fact that a change in source mode does not trigger `onChange` event. This is actually [a deliberate feature of CKeditor](https://dev.ckeditor.com/ticket/12031). We are overriding this by leveraging `onSetData`, that does trigger.
- The second bug is caused by incorrect handling of previous value in `useSyncValue`. With the change in this PR, we are always setting it. As I said in the JIRA ticket, I don't fully understand the purpose of syncing and checking of previous value. It is possible this would cause a regression in some other case. We introduced this behavior in https://github.com/liferay/liferay-portal/commit/026d8199510cd8aaa2c63ff0d568ee37baeef1f0#diff-fe1b0061663bd0ed50fc6f6028df7a4b69951453e9fe05c09e28b4266995ca48 , a long time ago. @matuzalemsteles do you remember why we did this? Is it safe to make the change in https://github.com/liferay-data-engine/liferay-portal/commit/62e039ec03bfacfcef71c358fcde26b24248b8f6?
- We are removing `data` prop. `ClassicEditor` is meant to work with `contents` prop, that we process before setting `data={contents}`. Overriding this may cause unwanted behavior in some edge cases that we cover in `ClassicEditor`.
- There is an unrelated bug, visible in below gifs: updating content does not update language dropdowns to `translated`. This is beyond the scope of this PR.

After PR, first bug fixed:
![after2](https://user-images.githubusercontent.com/5435511/122401987-5fcc0580-cf7d-11eb-8d1b-ae8516f1383b.gif)

After PR, second bug fixed:
![after1](https://user-images.githubusercontent.com/5435511/122402014-65c1e680-cf7d-11eb-99e5-4f4b014ce374.gif)