### PR TITLE
LPS-128735 Translation in CKEditor source mode is lost upon switching locales

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
@@ -16,7 +16,6 @@ import {ClassicEditor} from 'frontend-editor-ckeditor-web';
 import React, {useEffect, useRef, useState} from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
-import {useSyncValue} from '../hooks/useSyncValue.es';
 
 const RichText = ({
 	editingLanguageId,
@@ -30,10 +29,6 @@ const RichText = ({
 	visible,
 	...otherProps
 }) => {
-	const [currentValue, setCurrentValue] = useSyncValue(
-		value ? value : predefinedValue
-	);
-
 	const [dirty, setDirty] = useState(false);
 
 	const editorRef = useRef();
@@ -61,13 +56,11 @@ const RichText = ({
 			visible={visible}
 		>
 			<ClassicEditor
-				contents={currentValue}
-				data={currentValue}
+				contents={predefinedValue || value}
 				editorConfig={editorConfig}
 				name={name}
 				onChange={(data) => {
-					if (currentValue?.trim() !== data?.trim()) {
-						setCurrentValue(data);
+					if (value?.trim() !== data?.trim()) {
 						setDirty(true);
 
 						onChange({}, data);
@@ -76,18 +69,9 @@ const RichText = ({
 						CKEDITOR.instances[name]?.resetUndo();
 					}
 				}}
-				onMode={({editor}) => {
-					if (editor.mode === 'source') {
-						editor.on('afterSetData', ({data}) => {
-							const {dataValue} = data;
-
-							setCurrentValue(dataValue);
-
-							onChange({}, dataValue);
-						});
-					}
-					else {
-						editor.removeListener('afterSetData');
+				onSetData={(event) => {
+					if (event.editor.mode === 'source') {
+						onChange(event, event.data.dataValue);
 					}
 				}}
 				readOnly={readOnly}
@@ -95,7 +79,7 @@ const RichText = ({
 			/>
 
 			<input
-				defaultValue={currentValue}
+				defaultValue={predefinedValue || value}
 				id={id || name}
 				name={name}
 				type="hidden"


### PR DESCRIPTION
This is a followup on https://github.com/liferay-data-engine/liferay-portal/pull/541, see descriptions and discussions there.

TIL you cannot reopen a PR if the branch was force-pushed. I should have reopened it first, then pushed.

Anyways, after a suggestion from @matuzalemsteles in https://github.com/liferay-data-engine/liferay-portal/pull/541#issuecomment-863428072, I was able to reach a solution that behaves correctly in all three scenarios :tada:

But, now I cannot correctly save the form, due to an odd error in `fieldEditableReducer` (see gif). @rodrigopaulino @matuzalemsteles I am on PTO next two weeks, so I won't be able to continue with this, and you two have much better understanding of systems around the component. Please feel free to take over :slightly_smiling_face: 

![after](https://user-images.githubusercontent.com/5435511/122580915-c5d88b80-d056-11eb-9bb9-d3194e89f89a.gif)
