### PR TITLE
LPS-135082 Drools Upgrade tests failing on IBM DB2 11.1

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/DLServiceUpgrade.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/DLServiceUpgrade.java
@@ -23,7 +23,6 @@ import com.liferay.document.library.internal.upgrade.v1_1_0.SchemaUpgradeProcess
 import com.liferay.document.library.internal.upgrade.v1_1_2.DLFileEntryTypeUpgradeProcess;
 import com.liferay.document.library.internal.upgrade.v2_0_0.UpgradeCompanyId;
 import com.liferay.document.library.internal.upgrade.v3_2_1.DDMStructureLinkUpgradeProcess;
-import com.liferay.document.library.internal.upgrade.v3_2_2.UpgradeDDMStructureLinkDLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.portal.configuration.upgrade.PrefsPropsToConfigurationUpgradeHelper;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -109,8 +108,7 @@ public class DLServiceUpgrade implements UpgradeStepRegistrator {
 			new com.liferay.document.library.internal.upgrade.v3_2_1.
 				UpgradeDLFileEntryType());
 
-		registry.register(
-			"3.2.1", "3.2.2", new UpgradeDDMStructureLinkDLFileEntryType());
+		registry.register("3.2.1", "3.2.2", new DummyUpgradeStep());
 	}
 
 	@Reference

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/DDMServiceUpgrade.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/DDMServiceUpgrade.java
@@ -53,6 +53,7 @@ import com.liferay.dynamic.data.mapping.internal.upgrade.v3_5_0.DDMFormInstanceR
 import com.liferay.dynamic.data.mapping.internal.upgrade.v3_7_1.DDMStructureEmptyValidationUpgradeProcess;
 import com.liferay.dynamic.data.mapping.internal.upgrade.v4_1_0.DDMFieldUpgradeProcess;
 import com.liferay.dynamic.data.mapping.internal.upgrade.v4_3_0.DLFileEntryTypeDataDefinitionIdUpgradeProcess;
+import com.liferay.dynamic.data.mapping.internal.upgrade.v4_3_4.DDMStructureLinkDLFileEntryTypeUpgradeProcess;
 import com.liferay.dynamic.data.mapping.internal.upgrade.v4_3_4.DLFileEntryTypeDDMFieldAttributeUpgradeProcess;
 import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormLayoutDeserializer;
@@ -450,6 +451,8 @@ public class DDMServiceUpgrade implements UpgradeStepRegistrator {
 
 		registry.register(
 			"4.3.3", "4.3.4",
+			new DDMStructureLinkDLFileEntryTypeUpgradeProcess(
+				_dlFileEntryTypeLocalService),
 			new DLFileEntryTypeDDMFieldAttributeUpgradeProcess());
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_3_4/DDMStructureLinkDLFileEntryTypeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_3_4/DDMStructureLinkDLFileEntryTypeUpgradeProcess.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.internal.upgrade.v4_3_4;
 
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -27,7 +28,14 @@ import java.sql.ResultSet;
 /**
  * @author Alicia Garcia
  */
-public class UpgradeDDMStructureLinkDLFileEntryType extends UpgradeProcess {
+public class DDMStructureLinkDLFileEntryTypeUpgradeProcess
+	extends UpgradeProcess {
+
+	public DDMStructureLinkDLFileEntryTypeUpgradeProcess(
+		DLFileEntryTypeLocalService dlFileEntryTypeLocalService) {
+
+		_dlFileEntryTypeLocalService = dlFileEntryTypeLocalService;
+	}
 
 	@Override
 	protected void doUpgrade() throws Exception {
@@ -120,5 +128,7 @@ public class UpgradeDDMStructureLinkDLFileEntryType extends UpgradeProcess {
 			}
 		}
 	}
+
+	private final DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_3_4/UpgradeDDMStructureLinkDLFileEntryType.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_3_4/UpgradeDDMStructureLinkDLFileEntryType.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.document.library.internal.upgrade.v3_2_2;
+package com.liferay.dynamic.data.mapping.internal.upgrade.v4_3_4;
 
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.model.DLFileEntryType;


### PR DESCRIPTION
I couldn't test on DB2, but on 6.2 modifying the Database It made similar error with MySQL about the companyId column.

DL upgrade are made before DDM so in some cases companyID column was not created.

I tested https://issues.liferay.com/browse/LPS-133831 and https://issues.liferay.com/browse/LPS-133766 manually and seems to be ok