### PR TITLE
LPS-132723 Add new config for JournalArticleContent and update Journa…

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/rich/text/RichTextDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/rich/text/RichTextDDMFormFieldTemplateContextContributor.java
@@ -19,7 +19,6 @@ import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTy
 import com.liferay.dynamic.data.mapping.form.field.type.internal.util.DDMFormFieldTypeUtil;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderingContext;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
@@ -73,9 +72,13 @@ public class RichTextDDMFormFieldTemplateContextContributor
 		HttpServletRequest httpServletRequest =
 			ddmFormFieldRenderingContext.getHttpServletRequest();
 
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
 		EditorConfiguration editorConfiguration =
 			EditorConfigurationFactoryUtil.getEditorConfiguration(
-				StringPool.BLANK, ddmFormFieldType, "ckeditor_classic",
+				themeDisplay.getPpid(), ddmFormFieldType, "ckeditor_classic",
 				HashMapBuilder.<String, Object>put(
 					"liferay-ui:input-editor:allowBrowseDocuments", true
 				).put(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/service/dependencies/ddm/text-html.ftl
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/service/dependencies/ddm/text-html.ftl
@@ -32,6 +32,7 @@
 
 	<div class="form-group">
 		<@liferay_ui["input-editor"]
+			configKey="rich_text"
 			contents="${fieldValue}"
 			contentsLanguageId="${requestedLocale}"
 			cssClass="${cssClass}"

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/editor/configuration/JournalArticleContentEditorConfigContributor.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/editor/configuration/JournalArticleContentEditorConfigContributor.java
@@ -17,9 +17,7 @@ package com.liferay.journal.web.internal.editor.configuration;
 import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
-import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Validator;
@@ -29,16 +27,16 @@ import java.util.Map;
 import org.osgi.service.component.annotations.Component;
 
 /**
- * @author Pavel Savinov
+ * @author Fortunato Maldonado
  */
 @Component(
 	property = {
-		"editor.config.key=descriptionMapAsXMLEditor",
+		"editor.config.key=rich_text",
 		"javax.portlet.name=" + JournalPortletKeys.JOURNAL
 	},
 	service = EditorConfigContributor.class
 )
-public class JournalArticleDescriptionEditorConfigContributor
+public class JournalArticleContentEditorConfigContributor
 	extends BaseEditorConfigContributor {
 
 	@Override
@@ -47,17 +45,7 @@ public class JournalArticleDescriptionEditorConfigContributor
 		ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
-		jsonObject.put(
-			"allowedContent", "p br strong i ol ul li u link pre em a[href]"
-		).put(
-			"height", "120"
-		).put(
-			"pasteFilter", "p br strong i ol ul li u link pre em a[href]"
-		).put(
-			"resize_enabled", true
-		).put(
-			"toolbar", getToolbarJSONArray()
-		);
+		jsonObject.put("resize_enabled", true);
 
 		String removePlugins = jsonObject.getString("removePlugins");
 
@@ -69,13 +57,6 @@ public class JournalArticleDescriptionEditorConfigContributor
 		}
 
 		jsonObject.put("removePlugins", removePlugins);
-	}
-
-	protected JSONArray getToolbarJSONArray() {
-		return JSONUtil.putAll(
-			toJSONArray("['Bold', 'Italic', 'Underline']"),
-			toJSONArray("['NumberedList', 'BulletedList']"),
-			toJSONArray("['Link']"));
 	}
 
 }


### PR DESCRIPTION
FWD: https://github.com/brianchandotcom/liferay-portal/pull/104838
@rodrigopaulino, resending after the changes due to the comment from BChan: https://github.com/brianchandotcom/liferay-portal/pull/104838#issuecomment-887825457 

Original pull request comment:
FWD: liferay-data-engine#571
I was able to fix the issue and forwarding the new fix.

https://issues.liferay.com/browse/LPS-132723

It can be difficult for the user to use the web content toolbar options if the text is very long. This was verified as a bug in this comment: https://issues.liferay.com/browse/PTR-2478?focusedCommentId=2462821&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2462821

This is resolved by having "resize_enabled", true and disabling autogrow plugin for the editor. In order to do this, I had to create JournalArticleContentEditorConfigContributor to edit the Web Content and edit JournalArticleDescriptionEditorConfigContributor. I was able to check this change resolves the issue.

Let me know if there are any questions or comments about this.
Thank you.