### PR TITLE
[TS] LPS-128654

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/display/context/DDLViewRecordsDisplayContext.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/display/context/DDLViewRecordsDisplayContext.java
@@ -257,8 +257,7 @@ public class DDLViewRecordsDisplayContext {
 			navigationItem -> {
 				navigationItem.setActive(true);
 				navigationItem.setLabel(
-					HtmlUtil.extractText(
-						_ddlRecordSet.getName(_ddlRequestHelper.getLocale())));
+					_ddlRecordSet.getName(_ddlRequestHelper.getLocale()));
 			}
 		).build();
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/NavigationBarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/NavigationBarTag.java
@@ -16,6 +16,7 @@ package com.liferay.frontend.taglib.clay.servlet.taglib;
 
 import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.List;
@@ -127,7 +128,8 @@ public class NavigationBarTag extends BaseContainerTag {
 				}
 
 				jspWriter.write("><span class=\"navbar-text-truncate\">");
-				jspWriter.write((String)navigationItem.get("label"));
+				jspWriter.write(
+					HtmlUtil.escape((String)navigationItem.get("label")));
 				jspWriter.write("</span></a></li>");
 			}
 


### PR DESCRIPTION
[LPS-128654](https://issues.liferay.com/browse/LPS-128654)

From @leticia-maciel:

> **Issue**: DDL label was not showing up on the navbar.
> 
> **Solution**: The escape method was being set in the backend when in this case it should have been done in the frontend. For this, the `HtmlUtil.extractText` method was removed (line 260) from the `DDLViewRecordsDisplayContext.java` file which was returning the empty DDL label but the `HtmlUtil.escape` method was added (line 132) on the `NavigationBarTag.java` file where the string can be escaped correctly, without executing the script and showing the label the right way.