### PR TITLE
LPS-140633 Ensure ddmFormError is fired on error

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/FormView.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/FormView.es.js
@@ -72,6 +72,10 @@ const useFormSubmit = ({apiRef, containerRef}) => {
 						).length;
 
 						if (!validLiferayForm) {
+							Liferay.fire('ddmFormError', {
+								formWrapperId: event.target.id,
+							});
+
 							return;
 						}
 
@@ -97,6 +101,11 @@ const useFormSubmit = ({apiRef, containerRef}) => {
 				})
 				.catch((error) => {
 					console.error(error);
+
+					Liferay.fire('ddmFormError', {
+						error,
+						formWrapperId: event.target.id,
+					});
 				});
 		},
 		[apiRef, containerRef, submittable]


### PR DESCRIPTION
Hey team!

I am working on a [new feature request to enable autoSave in Web Content editor](https://issues.liferay.com/browse/LPS-140438). As part of it, I need JournalPortlet JS component to be notified whenever the ddm form is being save, but there are some cases there no 'ddm*' event is being fired. I added a couple of 'ddmFormError' triggers when some issue is encountered validating the form, and it looks it is working fine (no changes in the UI for now).