### PR TITLE
LPS-139522 Fixing a bug.

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/search/util/DDLRecordBatchReindexer.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/search/util/DDLRecordBatchReindexer.java
@@ -19,6 +19,6 @@ package com.liferay.dynamic.data.lists.internal.search.util;
  */
 public interface DDLRecordBatchReindexer {
 
-	public void reindex(long ddlRecordId, long companyId);
+	public void reindex(long ddlRecordSetId, long companyId);
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/search/util/DDLRecordBatchReindexerImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/search/util/DDLRecordBatchReindexerImpl.java
@@ -32,16 +32,16 @@ import org.osgi.service.component.annotations.Reference;
 public class DDLRecordBatchReindexerImpl implements DDLRecordBatchReindexer {
 
 	@Override
-	public void reindex(long ddlRecordId, long companyId) {
+	public void reindex(long ddlRecordSetId, long companyId) {
 		BatchIndexingActionable batchIndexingActionable =
 			indexerWriter.getBatchIndexingActionable();
 
 		batchIndexingActionable.setAddCriteriaMethod(
 			dynamicQuery -> {
 				Property recordIdProperty = PropertyFactoryUtil.forName(
-					"recordId");
+					"recordSetId");
 
-				dynamicQuery.add(recordIdProperty.eq(ddlRecordId));
+				dynamicQuery.add(recordIdProperty.eq(ddlRecordSetId));
 			});
 		batchIndexingActionable.setCompanyId(companyId);
 		batchIndexingActionable.setPerformActionMethod(


### PR DESCRIPTION
Hello @liferay-data-engine 

During the implementation of my LPS, I have been looking at other implementations of Search and I have found this in the one of DDLRecordSet that seems to be a bug.

The implementation that I have currently changed is only used from the DDLRecordSetModelIndexerWriterContributor.modelIndexed where the method is called using as the first parameter the ddlRecordSetId. 

https://github.com/liferay/liferay-portal/blob/0872f5919613e0b25368d844519cbd809d000df6/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/search/spi/model/index/contributor/DDLRecordSetModelIndexerWriterContributor.java#L64

But in the method implementation, the parameter is used as if it were a ddlRecordId, so I suspect that that query never has results.

https://github.com/liferay/liferay-portal/blob/07f59847b7db46a76172252d350d654783a7bc73/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/search/util/DDLRecordBatchReindexerImpl.java#L42

Please, could you check it out?

Thank you!

Regards