### PR TITLE
LPS-145422 Added spacer for breadcrumb elements

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -2437,9 +2437,9 @@ AUI.add(
 
 					breadcrumbContainer.empty();
 
-					var layoutsPathLenght = layoutsPath.length;
+					var layoutsPathLength = layoutsPath.length;
 
-					for (var index = 0; index < layoutsPathLenght; index++) {
+					for (var index = 0; index < layoutsPathLength; index++) {
 						var layoutPath = layoutsPath[index];
 
 						instance._addBreadcrumbElement(
@@ -2448,6 +2448,13 @@ AUI.add(
 							layoutPath.groupId,
 							layoutPath.privateLayout
 						);
+						if (index < layoutsPathLength - 1) {
+							var breadcrumbNode = instance._modal.bodyNode.one(
+								'.lfr-ddm-breadcrumb'
+							);
+
+							breadcrumbNode.append('&nbsp;&gt;&nbsp;');
+						}
 					}
 				},
 


### PR DESCRIPTION
Ticket: 
https://issues.liferay.com/browse/LPS-145422

Initial Review:
https://github.com/dacousalr/liferay-portal-ee/pull/268

Issue:
When viewing the form to _Select a Page_ for the Link to Page field, there is no clear separation between the breadcrumb elements.

Fix:
Added logic to add the appropriate spacer after each breadcrumb element.  

![image](https://user-images.githubusercontent.com/66975216/151231957-5666c1c7-e28c-43a4-bb41-79018c8e3646.png)
