### PR TITLE
LPS-155021 Add condition for fieldset label

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1092,26 +1092,37 @@ AUI.add(
 				setLabel(label) {
 					var instance = this;
 
-					var labelNode = instance.getLabelNode();
+					var fieldDefinition = instance.getFieldDefinition();
 
-					if (labelNode) {
-						var tipNode = labelNode.one('.taglib-icon-help');
+					if (fieldDefinition.type === 'fieldset') {
+						var containerNode = instance.get('container')._node;
 
-						if (
-							!A.UA.ie &&
-							Lang.isValue(label) &&
-							Lang.isNode(labelNode)
-						) {
-							labelNode.html(A.Escape.html(label));
+						var fieldSet = containerNode.getElementsByClassName(
+							'legend'
+						)[0];
+
+						fieldSet.textContent = label;
+					}
+					else {
+						var labelNode = instance.getLabelNode();
+
+						if (labelNode) {
+							var tipNode = labelNode.one('.taglib-icon-help');
+
+							if (
+								!A.UA.ie &&
+								Lang.isValue(label) &&
+								Lang.isNode(labelNode)
+							) {
+								labelNode.html(A.Escape.html(label));
+							}
+
+							if (!A.UA.ie && fieldDefinition.required) {
+								labelNode.append(TPL_REQUIRED_MARK);
+							}
+
+							instance._addTip(labelNode, tipNode);
 						}
-
-						var fieldDefinition = instance.getFieldDefinition();
-
-						if (!A.UA.ie && fieldDefinition.required) {
-							labelNode.append(TPL_REQUIRED_MARK);
-						}
-
-						instance._addTip(labelNode, tipNode);
 					}
 				},
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-155021

When a field is nested inside a `fieldset` and the user changes the language, the field's translation will be set to the translation of the `fieldset`, rather than its original translation. 
This is occurring since the `setLabel` looks for `instance.getLabelNode();`. This will result in getting the `field` information when the instance is the `fieldset`. The `field` will then be translated into the `fieldset` information.

In order to resolve this, I included a condition that will check if the type is a `fieldset` and correctly translate it.

Let me know if there are any questions or comments about this.
Thank you!